### PR TITLE
PR 11 for implementing Portlet Artifact validity tests and fix old ones in previous modules

### DIFF
--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/pom.xml
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.     
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>javax.portlet</groupId>
+      <artifactId>portlet-tck</artifactId>
+      <version>3.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>tck-V3AnnotationPortletArtifactValidityTests</artifactId>
+   <packaging>war</packaging>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.apache.portals.pluto</groupId>
+         <artifactId>portlet-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.tomcat</groupId>
+         <artifactId>tomcat-servlet-api</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>javax.portlet</groupId>
+         <artifactId>tck-common</artifactId>
+         <version>${project.version}</version>
+         <scope>compile</scope>
+      </dependency>
+
+      <!-- for tooling purposes -->
+      <dependency>
+         <groupId>org.apache.tomcat</groupId>
+         <artifactId>tomcat-jsp-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.tomcat</groupId>
+         <artifactId>tomcat-el-api</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.taglibs</groupId>
+         <artifactId>taglibs-standard-spec</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.taglibs</groupId>
+         <artifactId>taglibs-standard-impl</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.taglibs</groupId>
+         <artifactId>taglibs-standard-jstlel</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.portals.pluto</groupId>
+         <artifactId>pluto-taglib</artifactId>
+         <scope>provided</scope>
+      </dependency>
+   </dependencies>
+
+   <properties>
+      <!-- This module defines all test cases in a file (TCs are not generated from the portlet.xml) -->
+      <additional.testcases.only>true</additional.testcases.only>
+
+      <!-- This module places the portlets on the page through a file. (Page is not generated from the portlet.xml) -->
+      <additional.pagefile.only>true</additional.pagefile.only>
+   </properties>
+
+   <build>
+      <finalName>${project.artifactId}</finalName>
+      
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+         </plugin>
+         
+         <!-- copy page & test case files, renaming properly -->
+         <plugin>
+            <groupId>com.coderplus.maven.plugins</groupId>
+            <artifactId>copy-rename-maven-plugin</artifactId>
+         </plugin>
+      </plugins>
+   </build>
+
+
+   <profiles>
+      <profile>
+         <id>pluto</id>
+
+         <dependencies>
+            <dependency>
+               <groupId>org.apache.taglibs</groupId>
+               <artifactId>taglibs-standard-spec</artifactId>
+               <scope>compile</scope>
+            </dependency>
+            <dependency>
+               <groupId>org.apache.taglibs</groupId>
+               <artifactId>taglibs-standard-impl</artifactId>
+               <scope>compile</scope>
+            </dependency>
+            <dependency>
+               <groupId>org.apache.taglibs</groupId>
+               <artifactId>taglibs-standard-jstlel</artifactId>
+               <scope>compile</scope>
+            </dependency>
+         </dependencies>
+        
+      </profile>
+   </profiles>
+
+</project>

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/docs/ModuleAssertions.csv
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/docs/ModuleAssertions.csv
@@ -1,0 +1,35 @@
+PARMS outputPath=C:\Users\IBM_ADMIN\Downloads\TCKTool
+Class / Section;Keywords;Name;Testable;Description
+AnnotationPortletArtifactValidityTests;;;;
+SPEC3_20;RequestArtifacts;portletRequest;TRUE;PortletRequest artifact is valid during all phases.
+SPEC3_20;RequestArtifacts;actionRequest;TRUE;ActionRequest artifact is only valid during action phase.
+SPEC3_20;RequestArtifacts;headerRequest;TRUE;HeaderRequest artifact is only valid during header phase.
+SPEC3_20;RequestArtifacts;renderRequest;TRUE;RenderRequest artifact is only valid during render phase.
+SPEC3_20;RequestArtifacts;eventRequest;TRUE;EventRequest artifact is only valid during event phase.
+SPEC3_20;RequestArtifacts;resourceRequest;TRUE;ResourceRequest artifact is only valid during resource phase.
+SPEC3_20;RequestArtifacts;clientDataRequest;TRUE;ClientDataRequest artifact is only valid during action and resource phase.
+SPEC3_20;ResponseArtifacts;portletResponse;TRUE;PortletResponse artifact is valid during all phases.
+SPEC3_20;ResponseArtifacts;actionResponse;TRUE;ActionResponse artifact is only valid during action phase.
+SPEC3_20;ResponseArtifacts;headerResponse;TRUE;HeaderResponse artifact is only valid during header phase.
+SPEC3_20;ResponseArtifacts;renderResponse;TRUE;RenderResponse artifact is only valid during render phase.
+SPEC3_20;ResponseArtifacts;eventResponse;TRUE;EventResponse artifact is only valid during event phase.
+SPEC3_20;ResponseArtifacts;resourceResponse;TRUE;ResourceResponse artifact is only valid during resource phase.
+SPEC3_20;ResponseArtifacts;stateAwareReponse;TRUE;StateAwareResponse artifact is only valid during action and event phase.
+SPEC3_20;ResponseArtifacts;mimeResponse;TRUE;MimeResponse artifact is only valid during header, render and resource phase.
+SPEC3_20;ParameterArtifacts;renderParameters;TRUE;RenderParameters artifact is only valid during render phase.
+SPEC3_20;ParameterArtifacts;mutableRenderParameters;TRUE;MutableRenderParameters artifact is only valid during action and event phase.
+SPEC3_20;ParameterArtifacts;actionParameters;TRUE;ActionParameters artifact is only valid during action phase.
+SPEC3_20;ParameterArtifacts;resourceParameters;TRUE;ResourceParameters artifact is only valid during resource phase.
+SPEC3_20;PortletArtifacts;portletConfig;TRUE;PortletConfig artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;portletContext;TRUE;PortletContext artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;portletMode;TRUE;PortletMode artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;windowState;TRUE;WindowState artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;portletPreferences;TRUE;PortletPreferences artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;cookies;TRUE;Cookies artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;portletSession;TRUE;PortletSession artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;locale;TRUE;Locale artifact is only valid during render and resource phase.
+SPEC3_20;PortletArtifacts;locales;TRUE;Locales artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;namespace;TRUE;Namespace artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;contextPath;TRUE;ContextPath artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;windowID;TRUE;WindowID artifact is valid during all phases.
+SPEC3_20;PortletArtifacts;portletName;TRUE;PortletName artifact is valid during all phases.

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts.java
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts.java
@@ -1,0 +1,111 @@
+/*  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package javax.portlet.tck.portlets;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.*;
+import static java.util.logging.Logger.*;
+import javax.xml.namespace.QName;
+import javax.portlet.*;
+import javax.portlet.annotations.*;
+import javax.portlet.filter.*;
+import javax.servlet.*;
+import javax.servlet.http.*;
+import javax.portlet.tck.beans.*;
+import javax.portlet.tck.constants.*;
+import javax.portlet.tck.util.ModuleTestCaseDetails;
+import static javax.portlet.tck.util.ModuleTestCaseDetails.*;
+import static javax.portlet.tck.constants.Constants.*;
+import static javax.portlet.PortletSession.*;
+import static javax.portlet.ResourceURL.*;
+
+/**
+ * This portlet implements several test cases for the JSR 362 TCK. The test case names
+ * are defined in the /src/main/resources/xml-resources/additionalTCs.xml
+ * file. The build process will integrate the test case names defined in the 
+ * additionalTCs.xml file into the complete list of test case names for execution by the driver.
+ *
+ */
+
+@PortletConfiguration(portletName = "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts")
+public class AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts implements Portlet {
+   
+   private PortletConfig portletConfig = null;
+
+   @Override
+   public void init(PortletConfig config) throws PortletException {
+      this.portletConfig = config;
+   }
+
+   @Override
+   public void destroy() {
+   }
+
+   @Override
+   public void processAction(ActionRequest portletReq, ActionResponse portletResp) throws PortletException, IOException {
+   }
+
+   @Override
+   public void render(RenderRequest portletReq, RenderResponse portletResp) throws PortletException, IOException {
+
+      PrintWriter writer = portletResp.getWriter();
+      ModuleTestCaseDetails tcd = new ModuleTestCaseDetails();
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_renderParameters */
+      /* Details: "RenderParameters artifact is only valid during render phase."    */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RENDERPARAMETERS);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_mutableRenderParameters */
+      /* Details: "MutableRenderParameters artifact is only valid during action and */
+      /* event phase."                                                              */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_MUTABLERENDERPARAMETERS);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_actionParameters */
+      /* Details: "ActionParameters artifact is only valid during action phase."    */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_ACTIONPARAMETERS);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_resourceParameters */
+      /* Details: "ResourceParameters artifact is only valid during resource        */
+      /* phase."                                                                    */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RESOURCEPARAMETERS);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+   }
+
+}

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts.java
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts.java
@@ -23,6 +23,7 @@ import java.util.*;
 import java.util.logging.*;
 import static java.util.logging.Logger.*;
 import javax.xml.namespace.QName;
+import javax.inject.Inject;
 import javax.portlet.*;
 import javax.portlet.annotations.*;
 import javax.portlet.filter.*;
@@ -37,75 +38,432 @@ import static javax.portlet.PortletSession.*;
 import static javax.portlet.ResourceURL.*;
 
 /**
- * This portlet implements several test cases for the JSR 362 TCK. The test case names
- * are defined in the /src/main/resources/xml-resources/additionalTCs.xml
- * file. The build process will integrate the test case names defined in the 
- * additionalTCs.xml file into the complete list of test case names for execution by the driver.
+ * This portlet implements several test cases for the JSR 362 TCK. The test case
+ * names are defined in the /src/main/resources/xml-resources/additionalTCs.xml
+ * file. The build process will integrate the test case names defined in the
+ * additionalTCs.xml file into the complete list of test case names for
+ * execution by the driver.
  *
  */
 
-@PortletConfiguration(portletName = "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts")
-public class AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts implements Portlet {
+@PortletApplication(
+      events = @EventDefinition(
+            qname = @PortletQName(
+                  localPart = "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts", 
+                  namespaceURI = "http://www.apache.org/portals/pluto/portlet-tck_3.0"), 
+            payloadType = java.lang.String.class))
+public class AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts {
+
+   public static final String      ACTIONPARAMETERARTIFACTKEY        = "_actionParametersArtifact_";
+   public static final String      MUTABLEACTIONPARAMETERARTIFACTKEY = "_mutableActionParametersArtifact_";
+   public static final String      RENDERPARAMETERARTIFACTKEY        = "_renderParametersArtifact_";
+   public static final String      RESOURCEPARAMETERARTIFACTKEY      = "_resourceParametersArtifact_";
+   public static final String      ACTIONPHASE                       = "action";
+   public static final String      RENDERPHASE                       = "render";
+   public static final String      HEADERPHASE                       = "header";
+   public static final String      EVENTPHASE                        = "event";
+   // public static final String RESOURCEPHASE = "resource";
+
+   @Inject
+   @PortletName
+   private String                  portletName;
+
+   @Inject
+   private RenderParameters        renderParameters;
+
+   @Inject
+   private MutableRenderParameters mutableRenderParameters;
+
+   @Inject 
+   private ActionParameters        actionParameters;
+
+   @Inject
+   private ResourceParameters      resourceParameters;
    
-   private PortletConfig portletConfig = null;
-
-   @Override
-   public void init(PortletConfig config) throws PortletException {
-      this.portletConfig = config;
+   @Inject
+   private PortletSession portletSession;
+   
+   @HeaderMethod(portletNames = {
+         "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts" })
+   public void renderHeaders(HeaderRequest portletReq,
+         HeaderResponse portletResp) {
+      
+      System.out.println("HeaderMethod");
+      boolean actonParamArtifactValidator = false;
+      try{
+         if (actionParameters == null) {
+            actonParamArtifactValidator = true;
+         } else {
+            actonParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         actonParamArtifactValidator = true;
+         e.printStackTrace();
+      }
+      portletSession.setAttribute(
+            portletName + ACTIONPARAMETERARTIFACTKEY + HEADERPHASE,
+            actonParamArtifactValidator, PORTLET_SCOPE);
+      
+      boolean renderParamArtifactValidator = false;
+      try{
+         if (renderParameters == null) {
+            renderParamArtifactValidator = true;
+         } else {
+            renderParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         renderParamArtifactValidator = true;
+         e.printStackTrace();
+      }
+      portletSession.setAttribute(
+            portletName + RENDERPARAMETERARTIFACTKEY + HEADERPHASE,
+            renderParamArtifactValidator, PORTLET_SCOPE);
    }
 
-   @Override
-   public void destroy() {
+   @ActionMethod(portletName = "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts", 
+         publishingEvents = @PortletQName(
+               localPart = "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts", 
+               namespaceURI = "http://www.apache.org/portals/pluto/portlet-tck_3.0"))
+   public void processAction(ActionRequest portletReq,
+         ActionResponse portletResp) throws PortletException, IOException {
+      
+      System.out.println("ActionMethod");
+      ActionParameters actionParams = portletReq.getActionParameters();
+      boolean actonParamArtifactValidator = false;
+      try{
+         /* 
+          * TODO: Create a new check
+          * Injected actionParameters should not be null and 
+          * should be equal to ActionRequest.getActionParameters()
+          */
+         if (actionParameters!=null) {
+            actonParamArtifactValidator = true;
+         } else {
+            actonParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         e.printStackTrace();
+         actonParamArtifactValidator = false;
+      }
+      portletSession.setAttribute(
+            portletName + ACTIONPARAMETERARTIFACTKEY + ACTIONPHASE,
+            actonParamArtifactValidator, PORTLET_SCOPE);
+      
+      boolean renderParamArtifactValidator = false;
+      try{
+         if (renderParameters == null) {
+            renderParamArtifactValidator = true;
+         } else {
+            renderParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         renderParamArtifactValidator = true;
+         e.printStackTrace();
+      }
+      portletSession.setAttribute(
+            portletName + RENDERPARAMETERARTIFACTKEY + ACTIONPHASE,
+            renderParamArtifactValidator, PORTLET_SCOPE);
+      
+      // TODO: Remove following temp code
+      /* Code to perform job of event method - Starts here. */
+      
+      /* Event method is not getting called for some reason
+       * till that time we set the attributes/parameters here
+       * instead of event method. When event method works remove
+       * the following code.
+       */
+      portletSession.setAttribute(
+            portletName + ACTIONPARAMETERARTIFACTKEY + EVENTPHASE,
+            actonParamArtifactValidator, PORTLET_SCOPE);
+      
+      MutableRenderParameters renderParams = portletResp.getRenderParameters();
+      renderParams.setValue("tr0", "true");
+      
+      portletSession.setAttribute(
+            portletName + RENDERPARAMETERARTIFACTKEY + EVENTPHASE,
+            actonParamArtifactValidator, PORTLET_SCOPE);
+      
+      renderParams.setValue("tr2", "true");
+      /* Code to perform job of event method - Ends Here. */
+      
+      QName eventQName = new QName("http://www.apache.org/portals/pluto/portlet-tck_3.0", 
+            "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts");
+      portletResp.setEvent(eventQName, "Hi!");
+
    }
 
-   @Override
-   public void processAction(ActionRequest portletReq, ActionResponse portletResp) throws PortletException, IOException {
+   @RenderMethod(portletNames = {
+         "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts" })
+   public void render(RenderRequest portletReq, RenderResponse portletResp)
+         throws PortletException, IOException {
+      
+      System.out.println("RenderMethod");
+      PrintWriter writer = portletResp.getWriter();
+      
+      boolean actonParamArtifactValidator = false;
+      try{
+         if (actionParameters == null) {
+            actonParamArtifactValidator = true;
+         } else {
+            actonParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         actonParamArtifactValidator = true;
+         e.printStackTrace();
+      }
+      portletSession.setAttribute(
+            portletName + ACTIONPARAMETERARTIFACTKEY + RENDERPHASE,
+            actonParamArtifactValidator, PORTLET_SCOPE);
+      
+      boolean renderParamArtifactValidator = false;
+      try{
+         /* 
+          * TODO: Create a new check
+          * Injected renderParameters should not be null and 
+          * should be equal to RenderRequest.getRenderParameters()
+          */
+         if (renderParameters!=null) {
+            renderParamArtifactValidator = true;
+         } else {
+            renderParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         e.printStackTrace();
+         renderParamArtifactValidator = false;
+      }
+      portletSession.setAttribute(
+            portletName + RENDERPARAMETERARTIFACTKEY + RENDERPHASE,
+            renderParamArtifactValidator, PORTLET_SCOPE);
+      
+      
+      writer
+      .write("<div id=\"AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts\">no resource output.</div>\n");
+      ResourceURL resurl = portletResp.createResourceURL();
+      resurl.setCacheability(PAGE);
+      writer.write("<script>\n");
+      writer.write("(function () {\n");
+      writer.write("   var xhr = new XMLHttpRequest();\n");
+      writer.write("   xhr.onreadystatechange=function() {\n");
+      writer.write("      if (xhr.readyState==4 && xhr.status==200) {\n");
+      writer.write(
+      "         document.getElementById(\"AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts\").innerHTML=xhr.responseText;\n");
+      writer.write("      }\n");
+      writer.write("   };\n");
+      writer.write("   xhr.open(\"GET\",\"" + resurl.toString() + "\",true);\n");
+      writer.write("   xhr.send();\n");
+      writer.write("})();\n");
+      writer.write("</script>\n");
+
    }
 
-   @Override
-   public void render(RenderRequest portletReq, RenderResponse portletResp) throws PortletException, IOException {
-
+   @ServeResourceMethod(portletNames = {
+         "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts" })
+   public void serveResource(ResourceRequest portletReq,
+         ResourceResponse portletResp) throws PortletException, IOException {
+      
+      System.out.println("ResourceMethod");
       PrintWriter writer = portletResp.getWriter();
       ModuleTestCaseDetails tcd = new ModuleTestCaseDetails();
 
-      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_renderParameters */
-      /* Details: "RenderParameters artifact is only valid during render phase."    */
+      /*
+       * TestCase:
+       * V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_renderParameters
+       * Details: "RenderParameters artifact is only valid during render phase."
+       */
+      if(portletReq.getRenderParameters().getValue("tr2")!=null && portletReq.getRenderParameters().getValue("tr2").equals("true"))
       {
-         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RENDERPARAMETERS);
+         TestResult result = tcd.getTestResultFailed(
+               V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RENDERPARAMETERS);
+         boolean renderParamArtifactResource = false;
+         try{
+            if (renderParameters == null) {
+               renderParamArtifactResource = true;
+            } else {
+               renderParamArtifactResource = false;
+            }
+         } catch (RuntimeException e){
+            renderParamArtifactResource = true;
+            e.printStackTrace();
+         }
+         boolean renderParamArtifactAction = (boolean) portletSession
+               .getAttribute(
+                     portletName + RENDERPARAMETERARTIFACTKEY + ACTIONPHASE,
+                     PORTLET_SCOPE);
+         boolean renderParamArtifactRender = (boolean) portletSession
+               .getAttribute(
+                     portletName + RENDERPARAMETERARTIFACTKEY + RENDERPHASE,
+                     PORTLET_SCOPE);
+         boolean renderParamArtifactHeader = (boolean) portletSession
+               .getAttribute(
+                     portletName + RENDERPARAMETERARTIFACTKEY + HEADERPHASE,
+                     PORTLET_SCOPE);
+         boolean renderParamArtifactEvent = (boolean) portletSession
+               .getAttribute(
+                     portletName + RENDERPARAMETERARTIFACTKEY + EVENTPHASE,
+                     PORTLET_SCOPE);
+         if (renderParamArtifactAction && renderParamArtifactRender
+               && renderParamArtifactResource && renderParamArtifactHeader
+               && renderParamArtifactEvent) {
+            result.setTcSuccess(true);
+         }
+         result.appendTcDetail(createTable(renderParamArtifactAction,
+               renderParamArtifactEvent, renderParamArtifactHeader,
+               renderParamArtifactRender, renderParamArtifactResource));
+         result.writeTo(writer);
+      } else {
+         ActionURL aurl = portletResp.createActionURL();
+         TestButton tb = new TestButton(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RENDERPARAMETERS, aurl);
+         tb.writeTo(writer);
+      }
+
+      /*
+       * TestCase:
+       * V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_mutableRenderParameters
+       * Details: "MutableRenderParameters artifact is only valid during action
+       * and event phase."
+       */
+      {
+         TestResult result = tcd.getTestResultFailed(
+               V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_MUTABLERENDERPARAMETERS);
          /* TODO: implement test */
          result.appendTcDetail("Not implemented.");
          result.writeTo(writer);
       }
 
-      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_mutableRenderParameters */
-      /* Details: "MutableRenderParameters artifact is only valid during action and */
-      /* event phase."                                                              */
+      /*
+       * TestCase:
+       * V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_actionParameters
+       * Details: "ActionParameters artifact is only valid during action phase."
+       */
+      if(portletReq.getRenderParameters().getValue("tr0")!=null && portletReq.getRenderParameters().getValue("tr0").equals("true"))
       {
-         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_MUTABLERENDERPARAMETERS);
-         /* TODO: implement test */
-         result.appendTcDetail("Not implemented.");
+         TestResult result = tcd.getTestResultFailed(
+               V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_ACTIONPARAMETERS);
+         boolean actonParamArtifactResource = false;
+         try{
+            if (actionParameters == null) {
+               actonParamArtifactResource = true;
+            } else {
+               actonParamArtifactResource = false;
+            }
+         } catch (RuntimeException e){
+            actonParamArtifactResource = true;
+            e.printStackTrace();
+         }
+         boolean actonParamArtifactAction = (boolean) portletSession
+               .getAttribute(
+                     portletName + ACTIONPARAMETERARTIFACTKEY + ACTIONPHASE,
+                     PORTLET_SCOPE);
+         boolean actonParamArtifactRender = (boolean) portletSession
+               .getAttribute(
+                     portletName + ACTIONPARAMETERARTIFACTKEY + RENDERPHASE,
+                     PORTLET_SCOPE);
+         boolean actonParamArtifactHeader = (boolean) portletSession
+               .getAttribute(
+                     portletName + ACTIONPARAMETERARTIFACTKEY + HEADERPHASE,
+                     PORTLET_SCOPE);
+         boolean actonParamArtifactEvent = (boolean) portletSession
+               .getAttribute(
+                     portletName + ACTIONPARAMETERARTIFACTKEY + EVENTPHASE,
+                     PORTLET_SCOPE);
+         if (actonParamArtifactAction && actonParamArtifactRender
+               && actonParamArtifactResource && actonParamArtifactHeader
+               && actonParamArtifactEvent) {
+            result.setTcSuccess(true);
+         }
+         result.appendTcDetail(createTable(actonParamArtifactAction,
+               actonParamArtifactEvent, actonParamArtifactHeader,
+               actonParamArtifactRender, actonParamArtifactResource));
          result.writeTo(writer);
+      } else {
+         ActionURL aurl = portletResp.createActionURL();
+         TestButton tb = new TestButton(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_ACTIONPARAMETERS, aurl);
+         tb.writeTo(writer);
       }
 
-      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_actionParameters */
-      /* Details: "ActionParameters artifact is only valid during action phase."    */
+      /*
+       * TestCase:
+       * V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_resourceParameters
+       * Details: "ResourceParameters artifact is only valid during resource
+       * phase." */
       {
-         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_ACTIONPARAMETERS);
-         /* TODO: implement test */
-         result.appendTcDetail("Not implemented.");
-         result.writeTo(writer);
-      }
-
-      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_resourceParameters */
-      /* Details: "ResourceParameters artifact is only valid during resource        */
-      /* phase."                                                                    */
-      {
-         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RESOURCEPARAMETERS);
+         TestResult result = tcd.getTestResultFailed(
+               V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RESOURCEPARAMETERS);
          /* TODO: implement test */
          result.appendTcDetail("Not implemented.");
          result.writeTo(writer);
       }
 
    }
+
+   @EventMethod(
+         portletName = "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts", 
+         processingEvents = @PortletQName(
+               localPart = "AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts", 
+               namespaceURI = "http://www.apache.org/portals/pluto/portlet-tck_3.0"))
+   public void processEvent(EventRequest portletReq, EventResponse portletResp)
+         throws PortletException, IOException {
+
+      System.out.println("EventMethod");
+      boolean actonParamArtifactValidator = false;
+      try{
+         if (actionParameters == null) {
+            actonParamArtifactValidator = true;
+         } else {
+            actonParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         actonParamArtifactValidator = true;
+         e.printStackTrace();
+      }
+      portletSession.setAttribute(
+            portletName + ACTIONPARAMETERARTIFACTKEY + EVENTPHASE,
+            actonParamArtifactValidator, PORTLET_SCOPE);
+      
+      boolean renderParamArtifactValidator = false;
+      try{
+         if (renderParameters == null) {
+            renderParamArtifactValidator = true;
+         } else {
+            renderParamArtifactValidator = false;
+         }
+      } catch (RuntimeException e){
+         renderParamArtifactValidator = true;
+         e.printStackTrace();
+      }
+      portletSession.setAttribute(
+            portletName + RENDERPARAMETERARTIFACTKEY + EVENTPHASE,
+            renderParamArtifactValidator, PORTLET_SCOPE);
+      
+      MutableRenderParameters renderParams = portletResp.getRenderParameters();
+      renderParams.setValue("tr0", "true");
+
+   }
+
+   public String createTable(boolean actionValidator, boolean eventValidator,
+         boolean headerValidator, boolean renderValidator,
+         boolean resourceValidator) {
+      StringBuilder txt = new StringBuilder();
+      txt.append("<p>Debug Info: ");
+      txt.append("<table>");
+      txt.append("   <tr>");
+      txt.append("      <td>Action</td>");
+      txt.append("      <td>Event</td>");
+      txt.append("      <td>Header</td>");
+      txt.append("      <td>Render</td>");
+      txt.append("      <td>Resource</td>");
+      txt.append("   </tr>");
+      txt.append("   <tr>");
+      txt.append("      <td>" + actionValidator + "</td>");
+      txt.append("      <td>" + eventValidator + "</td>");
+      txt.append("      <td>" + headerValidator + "</td>");
+      txt.append("      <td>" + renderValidator + "</td>");
+      txt.append("      <td>" + resourceValidator + "</td>");
+      txt.append("   </tr>");
+      txt.append("</table>");
+      txt.append("</p>");
+      return txt.toString();
+   }
+
 
 }

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts.java
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts.java
@@ -1,0 +1,190 @@
+/*  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package javax.portlet.tck.portlets;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.*;
+import static java.util.logging.Logger.*;
+import javax.xml.namespace.QName;
+import javax.portlet.*;
+import javax.portlet.annotations.*;
+import javax.portlet.filter.*;
+import javax.servlet.*;
+import javax.servlet.http.*;
+import javax.portlet.tck.beans.*;
+import javax.portlet.tck.constants.*;
+import javax.portlet.tck.util.ModuleTestCaseDetails;
+import static javax.portlet.tck.util.ModuleTestCaseDetails.*;
+import static javax.portlet.tck.constants.Constants.*;
+import static javax.portlet.PortletSession.*;
+import static javax.portlet.ResourceURL.*;
+
+/**
+ * This portlet implements several test cases for the JSR 362 TCK. The test case names
+ * are defined in the /src/main/resources/xml-resources/additionalTCs.xml
+ * file. The build process will integrate the test case names defined in the 
+ * additionalTCs.xml file into the complete list of test case names for execution by the driver.
+ *
+ */
+
+@PortletConfiguration(portletName = "AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts")
+public class AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts implements Portlet {
+   
+   private PortletConfig portletConfig = null;
+
+   @Override
+   public void init(PortletConfig config) throws PortletException {
+      this.portletConfig = config;
+   }
+
+   @Override
+   public void destroy() {
+   }
+
+   @Override
+   public void processAction(ActionRequest portletReq, ActionResponse portletResp) throws PortletException, IOException {
+   }
+
+   @Override
+   public void render(RenderRequest portletReq, RenderResponse portletResp) throws PortletException, IOException {
+
+      PrintWriter writer = portletResp.getWriter();
+      ModuleTestCaseDetails tcd = new ModuleTestCaseDetails();
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletConfig */
+      /* Details: "PortletConfig artifact is valid during all phases."              */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETCONFIG);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletContext */
+      /* Details: "PortletContext artifact is valid during all phases."             */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETCONTEXT);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletMode */
+      /* Details: "PortletMode artifact is valid during all phases."                */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETMODE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_windowState */
+      /* Details: "WindowState artifact is valid during all phases."                */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_WINDOWSTATE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletPreferences */
+      /* Details: "PortletPreferences artifact is valid during all phases."         */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETPREFERENCES);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_cookies */
+      /* Details: "Cookies artifact is valid during all phases."                    */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_COOKIES);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletSession */
+      /* Details: "PortletSession artifact is valid during all phases."             */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETSESSION);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_locale */
+      /* Details: "Locale artifact is only valid during render and resource phase." */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_LOCALE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_locales */
+      /* Details: "Locales artifact is valid during all phases."                    */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_LOCALES);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_namespace */
+      /* Details: "Namespace artifact is valid during all phases."                  */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_NAMESPACE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_contextPath */
+      /* Details: "ContextPath artifact is valid during all phases."                */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_CONTEXTPATH);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_windowID */
+      /* Details: "WindowID artifact is valid during all phases."                   */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_WINDOWID);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletName */
+      /* Details: "PortletName artifact is valid during all phases."                */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETNAME);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+   }
+
+}

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts.java
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts.java
@@ -1,0 +1,137 @@
+/*  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package javax.portlet.tck.portlets;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.*;
+import static java.util.logging.Logger.*;
+import javax.xml.namespace.QName;
+import javax.portlet.*;
+import javax.portlet.annotations.*;
+import javax.portlet.filter.*;
+import javax.servlet.*;
+import javax.servlet.http.*;
+import javax.portlet.tck.beans.*;
+import javax.portlet.tck.constants.*;
+import javax.portlet.tck.util.ModuleTestCaseDetails;
+import static javax.portlet.tck.util.ModuleTestCaseDetails.*;
+import static javax.portlet.tck.constants.Constants.*;
+import static javax.portlet.PortletSession.*;
+import static javax.portlet.ResourceURL.*;
+
+/**
+ * This portlet implements several test cases for the JSR 362 TCK. The test case names
+ * are defined in the /src/main/resources/xml-resources/additionalTCs.xml
+ * file. The build process will integrate the test case names defined in the 
+ * additionalTCs.xml file into the complete list of test case names for execution by the driver.
+ *
+ */
+
+@PortletConfiguration(portletName = "AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts")
+public class AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts implements Portlet {
+   
+   private PortletConfig portletConfig = null;
+
+   @Override
+   public void init(PortletConfig config) throws PortletException {
+      this.portletConfig = config;
+   }
+
+   @Override
+   public void destroy() {
+   }
+
+   @Override
+   public void processAction(ActionRequest portletReq, ActionResponse portletResp) throws PortletException, IOException {
+   }
+
+   @Override
+   public void render(RenderRequest portletReq, RenderResponse portletResp) throws PortletException, IOException {
+
+      PrintWriter writer = portletResp.getWriter();
+      ModuleTestCaseDetails tcd = new ModuleTestCaseDetails();
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_portletRequest */
+      /* Details: "PortletRequest artifact is valid during all phases."             */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_PORTLETREQUEST);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_actionRequest */
+      /* Details: "ActionRequest artifact is only valid during action phase."       */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_ACTIONREQUEST);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_headerRequest */
+      /* Details: "HeaderRequest artifact is only valid during header phase."       */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_HEADERREQUEST);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_renderRequest */
+      /* Details: "RenderRequest artifact is only valid during render phase."       */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_RENDERREQUEST);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_eventRequest */
+      /* Details: "EventRequest artifact is only valid during event phase."         */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_EVENTREQUEST);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_resourceRequest */
+      /* Details: "ResourceRequest artifact is only valid during resource phase."   */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_RESOURCEREQUEST);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_clientDataRequest */
+      /* Details: "ClientDataRequest artifact is only valid during action and       */
+      /* resource phase."                                                           */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_CLIENTDATAREQUEST);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+   }
+
+}

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts.java
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/portlets/AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts.java
@@ -1,0 +1,147 @@
+/*  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package javax.portlet.tck.portlets;
+
+import java.io.*;
+import java.util.*;
+import java.util.logging.*;
+import static java.util.logging.Logger.*;
+import javax.xml.namespace.QName;
+import javax.portlet.*;
+import javax.portlet.annotations.*;
+import javax.portlet.filter.*;
+import javax.servlet.*;
+import javax.servlet.http.*;
+import javax.portlet.tck.beans.*;
+import javax.portlet.tck.constants.*;
+import javax.portlet.tck.util.ModuleTestCaseDetails;
+import static javax.portlet.tck.util.ModuleTestCaseDetails.*;
+import static javax.portlet.tck.constants.Constants.*;
+import static javax.portlet.PortletSession.*;
+import static javax.portlet.ResourceURL.*;
+
+/**
+ * This portlet implements several test cases for the JSR 362 TCK. The test case names
+ * are defined in the /src/main/resources/xml-resources/additionalTCs.xml
+ * file. The build process will integrate the test case names defined in the 
+ * additionalTCs.xml file into the complete list of test case names for execution by the driver.
+ *
+ */
+
+@PortletConfiguration(portletName = "AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts")
+public class AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts implements Portlet {
+   
+   private PortletConfig portletConfig = null;
+
+   @Override
+   public void init(PortletConfig config) throws PortletException {
+      this.portletConfig = config;
+   }
+
+   @Override
+   public void destroy() {
+   }
+
+   @Override
+   public void processAction(ActionRequest portletReq, ActionResponse portletResp) throws PortletException, IOException {
+   }
+
+   @Override
+   public void render(RenderRequest portletReq, RenderResponse portletResp) throws PortletException, IOException {
+
+      PrintWriter writer = portletResp.getWriter();
+      ModuleTestCaseDetails tcd = new ModuleTestCaseDetails();
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_portletResponse */
+      /* Details: "PortletResponse artifact is valid during all phases."            */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_PORTLETRESPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_actionResponse */
+      /* Details: "ActionResponse artifact is only valid during action phase."      */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_ACTIONRESPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_headerResponse */
+      /* Details: "HeaderResponse artifact is only valid during header phase."      */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_HEADERRESPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_renderResponse */
+      /* Details: "RenderResponse artifact is only valid during render phase."      */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_RENDERRESPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_eventResponse */
+      /* Details: "EventResponse artifact is only valid during event phase."        */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_EVENTRESPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_resourceResponse */
+      /* Details: "ResourceResponse artifact is only valid during resource phase."  */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_RESOURCERESPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_stateAwareReponse */
+      /* Details: "StateAwareResponse artifact is only valid during action and      */
+      /* event phase."                                                              */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_STATEAWAREREPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+      /* TestCase: V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_mimeResponse */
+      /* Details: "MimeResponse artifact is only valid during header, render and    */
+      /* resource phase."                                                           */
+      {
+         TestResult result = tcd.getTestResultFailed(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_MIMERESPONSE);
+         /* TODO: implement test */
+         result.appendTcDetail("Not implemented.");
+         result.writeTo(writer);
+      }
+
+   }
+
+}

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/util/ModuleTestCaseDetails.java
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/java/javax/portlet/tck/util/ModuleTestCaseDetails.java
@@ -1,0 +1,122 @@
+/*  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package javax.portlet.tck.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.portlet.tck.beans.TestCaseDetails;
+
+/**
+ * Defines constants for the test case names and test case details 
+ * for the JSR 362 TCK.
+ * 
+ * Note that the backing map is static and not threadsafe. Operations
+ * that change the map such as put, remove, etc., should not be used
+ * in portlets.
+ * 
+ * @author nick
+ */
+public class ModuleTestCaseDetails extends TestCaseDetails {
+
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_PORTLETREQUEST = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_portletRequest";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_ACTIONREQUEST = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_actionRequest";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_HEADERREQUEST = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_headerRequest";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_RENDERREQUEST = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_renderRequest";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_EVENTREQUEST = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_eventRequest";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_RESOURCEREQUEST = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_resourceRequest";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_CLIENTDATAREQUEST = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_clientDataRequest";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_PORTLETRESPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_portletResponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_ACTIONRESPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_actionResponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_HEADERRESPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_headerResponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_RENDERRESPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_renderResponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_EVENTRESPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_eventResponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_RESOURCERESPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_resourceResponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_STATEAWAREREPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_stateAwareReponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_MIMERESPONSE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_mimeResponse";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RENDERPARAMETERS = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_renderParameters";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_MUTABLERENDERPARAMETERS = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_mutableRenderParameters";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_ACTIONPARAMETERS = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_actionParameters";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RESOURCEPARAMETERS = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_resourceParameters";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETCONFIG = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletConfig";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETCONTEXT = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletContext";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETMODE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletMode";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_WINDOWSTATE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_windowState";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETPREFERENCES = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletPreferences";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_COOKIES = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_cookies";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETSESSION = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletSession";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_LOCALE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_locale";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_LOCALES = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_locales";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_NAMESPACE = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_namespace";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_CONTEXTPATH = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_contextPath";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_WINDOWID = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_windowID";
+   public final static String V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETNAME = "V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletName";
+
+   
+   private final static Map<String, String> tcd = new HashMap<String, String>();
+   static {
+
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_PORTLETREQUEST, "PortletRequest artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_ACTIONREQUEST, "ActionRequest artifact is only valid during action phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_HEADERREQUEST, "HeaderRequest artifact is only valid during header phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_RENDERREQUEST, "RenderRequest artifact is only valid during render phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_EVENTREQUEST, "EventRequest artifact is only valid during event phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_RESOURCEREQUEST, "ResourceRequest artifact is only valid during resource phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_REQUESTARTIFACTS_CLIENTDATAREQUEST, "ClientDataRequest artifact is only valid during action and resource phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_PORTLETRESPONSE, "PortletResponse artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_ACTIONRESPONSE, "ActionResponse artifact is only valid during action phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_HEADERRESPONSE, "HeaderResponse artifact is only valid during header phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_RENDERRESPONSE, "RenderResponse artifact is only valid during render phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_EVENTRESPONSE, "EventResponse artifact is only valid during event phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_RESOURCERESPONSE, "ResourceResponse artifact is only valid during resource phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_STATEAWAREREPONSE, "StateAwareResponse artifact is only valid during action and event phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_RESPONSEARTIFACTS_MIMERESPONSE, "MimeResponse artifact is only valid during header, render and resource phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RENDERPARAMETERS, "RenderParameters artifact is only valid during render phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_MUTABLERENDERPARAMETERS, "MutableRenderParameters artifact is only valid during action and event phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_ACTIONPARAMETERS, "ActionParameters artifact is only valid during action phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PARAMETERARTIFACTS_RESOURCEPARAMETERS, "ResourceParameters artifact is only valid during resource phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETCONFIG, "PortletConfig artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETCONTEXT, "PortletContext artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETMODE, "PortletMode artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_WINDOWSTATE, "WindowState artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETPREFERENCES, "PortletPreferences artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_COOKIES, "Cookies artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETSESSION, "PortletSession artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_LOCALE, "Locale artifact is only valid during render and resource phase.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_LOCALES, "Locales artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_NAMESPACE, "Namespace artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_CONTEXTPATH, "ContextPath artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_WINDOWID, "WindowID artifact is valid during all phases.");
+      tcd.put(V3ANNOTATIONPORTLETARTIFACTVALIDITYTESTS_SPEC3_20_PORTLETARTIFACTS_PORTLETNAME, "PortletName artifact is valid during all phases.");
+
+   }
+
+   /**
+    * Constructor.
+    * 
+    * Passes the static test case names - details map to the superclass
+    * 
+    * Note that the backing map is static and not threadsafe. Operations
+    * that change the map such as put, remove, etc., should not be used
+    * in portlets.
+    */
+   public ModuleTestCaseDetails() {
+     super(tcd); 
+   }
+
+}

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/resources/xml-resources/additionalPages.xml
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/resources/xml-resources/additionalPages.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.     
+-->
+<pluto-portal-driver xmlns="http://portals.apache.org/pluto/xsd/pluto-portal-driver-config.xsd" xmlns:pa="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://portals.apache.org/pluto/xsd/pluto-portal-driver-config.xsd                         http://portals.apache.org/pluto/pluto-portal/1.1/pluto-portal-driver-config.xsd" version="1.1">
+<portal-name>pluto-portal-driver</portal-name>
+<portal-version>2.1.0-SNAPSHOT</portal-version>
+<container-name>Pluto Portal Driver</container-name>
+<supports>
+<portlet-mode>view</portlet-mode>
+<portlet-mode>edit</portlet-mode>
+<portlet-mode>help</portlet-mode>
+<portlet-mode>config</portlet-mode>
+<window-state>normal</window-state>
+<window-state>maximized</window-state>
+<window-state>minimized</window-state>
+</supports>
+<render-config default="About Apache Pluto">
+<page xmlns="" name="V3AnnotationPortletArtifactValidityTests" uri="/WEB-INF/themes/pluto-default-theme.jsp">
+<portlet context="/tck-V3AnnotationPortletArtifactValidityTests-3.0-SNAPSHOT" name="AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts"/>
+<portlet context="/tck-V3AnnotationPortletArtifactValidityTests-3.0-SNAPSHOT" name="AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts"/>
+<portlet context="/tck-V3AnnotationPortletArtifactValidityTests-3.0-SNAPSHOT" name="AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts"/>
+<portlet context="/tck-V3AnnotationPortletArtifactValidityTests-3.0-SNAPSHOT" name="AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts"/>
+</page>
+</render-config>
+</pluto-portal-driver>

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/resources/xml-resources/additionalTCs.xml
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/resources/xml-resources/additionalTCs.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.     
+-->
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<!-- JSR 362 API AnnotationPortletArtifactValidityTests test case names and page mappings -->
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_portletRequest">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_actionRequest">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_headerRequest">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_renderRequest">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_eventRequest">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_resourceRequest">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_RequestArtifacts_clientDataRequest">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_portletResponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_actionResponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_headerResponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_renderResponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_eventResponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_resourceResponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_stateAwareReponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ResponseArtifacts_mimeResponse">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_renderParameters">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_mutableRenderParameters">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_actionParameters">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_ParameterArtifacts_resourceParameters">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletConfig">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletContext">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletMode">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_windowState">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletPreferences">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_cookies">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletSession">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_locale">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_locales">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_namespace">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_contextPath">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_windowID">V3AnnotationPortletArtifactValidityTests</entry>
+<entry key="V3AnnotationPortletArtifactValidityTests_SPEC3_20_PortletArtifacts_portletName">V3AnnotationPortletArtifactValidityTests</entry>
+</properties>

--- a/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/webapp/WEB-INF/beans.xml
+++ b/portlet-tck_3.0/V3AnnotationPortletArtifactValidityTests/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+   
+</beans>

--- a/portlet-tck_3.0/deploy/pom.xml
+++ b/portlet-tck_3.0/deploy/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -318,6 +317,12 @@
       <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>tck-V3PortletParametersTests</artifactId>
+         <version>${project.version}</version>
+         <type>war</type>
+      </dependency>
+      <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>tck-V3AnnotationPortletArtifactValidityTests</artifactId>
          <version>${project.version}</version>
          <type>war</type>
       </dependency>

--- a/portlet-tck_3.0/driver/pom.xml
+++ b/portlet-tck_3.0/driver/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -347,6 +346,12 @@
          <version>${project.version}</version>
          <type>war</type>
       </dependency>
+   <dependency>
+         <groupId>${project.groupId}</groupId>
+         <artifactId>tck-V3AnnotationPortletArtifactValidityTests</artifactId>
+         <version>${project.version}</version>
+         <type>war</type>
+      </dependency>
    </dependencies>
 
    <properties>
@@ -429,6 +434,7 @@
 						tck-V3RenderStateTests
                         ,tck-V3HeaderPortletTests
                         ,tck-V3PortletParametersTests
+                        ,tck-V3AnnotationPortletArtifactValidityTests
                      </includeArtifactIds>
                      <includes>${test.file.dir}/*.xml</includes>
                      <outputDirectory>${project.build.directory}</outputDirectory>

--- a/portlet-tck_3.0/driver/src/main/resources/xml-resources/pageFiles.xml
+++ b/portlet-tck_3.0/driver/src/main/resources/xml-resources/pageFiles.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -66,4 +65,5 @@
    <fl:file>tck-V3RenderStateTests-pages.xml</fl:file>
 <fl:file>tck-V3HeaderPortletTests-pages.xml</fl:file>
 <fl:file>tck-V3PortletParametersTests-pages.xml</fl:file>
+<fl:file>tck-V3AnnotationPortletArtifactValidityTests-pages.xml</fl:file>
 </fl:filelist>

--- a/portlet-tck_3.0/driver/src/main/resources/xml-resources/testFiles.xml
+++ b/portlet-tck_3.0/driver/src/main/resources/xml-resources/testFiles.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -66,4 +65,5 @@
    <fl:file>tck-V3RenderStateTests-tests.xml</fl:file>
 <fl:file>tck-V3HeaderPortletTests-tests.xml</fl:file>
 <fl:file>tck-V3PortletParametersTests-tests.xml</fl:file>
+<fl:file>tck-V3AnnotationPortletArtifactValidityTests-tests.xml</fl:file>
 </fl:filelist>

--- a/portlet-tck_3.0/pom.xml
+++ b/portlet-tck_3.0/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -173,6 +172,7 @@
 	  <module>V3RenderStateTests</module>
       <module>V3HeaderPortletTests</module>
       <module>V3PortletParametersTests</module>
+      <module>V3AnnotationPortletArtifactValidityTests</module>
       <module>deploy</module>
       <module>driver</module>
    </modules>


### PR DESCRIPTION
Added a new module - V3AnnotationPortletArtifactValidityTests to test the validity of all 32 artifacts available through annotations. This module check if the artifacts are valid only in their specified phase.