### PR TITLE
Tomee and wildfly distribution

### DIFF
--- a/dist-payara-build.xml
+++ b/dist-payara-build.xml
@@ -56,8 +56,8 @@
    war files to be able to deploy them to Pluto using the admin portlet. 
 -->
 <project name="PlutoPayaraDistributions" default="bundle-dist">
-
-    <property name="payara.full.version" value="4.1.1.171.0.1" description="Full version of Payara to deploy Pluto war files."/>
+                                                
+    <property name="payara.full.version" value="4.1.1.171.1" description="Full version of Payara to deploy Pluto war files."/>
 
     <xmlproperty file="pom.xml"/> <!-- picks up pluto build version from pom file -->
     <property name="pluto.version" value="${project.version}" description="Version of Pluto to build"/>
@@ -157,7 +157,7 @@
         <delete dir="${dist.basedir}" failonerror="false"/>
         <mkdir dir="${dist.basedir}"/>
         <mkdir dir="${cache.dir}" />
-        
+                  
         <get src="https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+${payara.full.version}/payara-${payara.full.version}.zip"
              dest="${download.file}" skipexisting="true" />
 

--- a/dist-payara-build.xml
+++ b/dist-payara-build.xml
@@ -21,62 +21,63 @@
    Prerequisites for this build includes an installed Java 5+ JDK, Maven 2.0+ and Ant 1.6+.
    
    Run the binary build using the command line:
-      ant -f dist-wildfly-build.xml
+      ant -f dist-payara-build.xml
 
    Or if you want to include the demo portlet WARs:
-      ant -f dist-wildfly-build.xml -DincludeDemos=true
+      ant -f dist-payara-build.xml -DincludeDemos=true
 
    If you want to package the TCK source & deliverables (warning: produces large files!):
-      ant -f dist-wildfly-build.xml -DpackageTck=true
+      ant -f dist-payara-build.xml -DpackageTck=true
       
-   If you want to retain the intermediate products (tomcat directory), add the noClean flag:
-      ant -f dist-wildfly-build.xml -DincludeDemos=true -DnoClean=true
+   If you want to retain the intermediate products (payara directory), add the noClean flag:
+      ant -f dist-payara-build.xml -DincludeDemos=true -DnoClean=true
       
    If you want to just package an existing build without cleaning and recompiling first, 
    add the packageOnly flag:
-      ant -f dist-wildfly-build.xml -DincludeDemos=true -DpackageOnly=true
+      ant -f dist-payara-build.xml -DincludeDemos=true -DpackageOnly=true
 
    The bundled distribution is done in the following way:
-   1. Downloads wildfly and unzips it into a working directory. To this distribution, the
+   1. Downloads payara and unzips it into a working directory. To this distribution, the
       build:
       a. Adds a pluto user with pluto to application users
       b. Create module.xml files for pluto dependencies
       c. Add pluto in global-modules in standalone.xml
    2. Runs 'mvn install' and 'mvn dependency:copy' to create the Pluto driver and testsuite 
       and installs them into the Tomee dist in the working directory.
-   3. Archives the altered Wildfly dist with Pluto into a zip, gzip and bzip2 file.
+   3. Archives the altered payara dist with Pluto into a zip, gzip and bzip2 file.
    
    All built distributions end up in target/dist.
    
-   After unarchiving the built distribution into a directory, invoke the standalone startup script in the bin
+   After unarchiving the built distribution into a directory, invoke the './asadmin start-domain' in the bin
    directory and browse to: http://localhost:8080/pluto/portal/
    
    Login as 'pluto' (password=pluto) to the portal. You will need to login again into the manager
    application linked at the bottom of the Pluto Admin page in order to upload portlet application
    war files to be able to deploy them to Pluto using the admin portlet. 
 -->
-<project name="PlutoWildflyDistributions" default="bundle-dist">
+<project name="PlutoPayaraDistributions" default="bundle-dist">
 
-    <property name="wildfly.full.version" value="10.1.0.Final" description="Full version of Wildfly to deploy Pluto war files."/>
+    <property name="payara.full.version" value="4.1.1.171.0.1" description="Full version of Payara to deploy Pluto war files."/>
 
     <xmlproperty file="pom.xml"/> <!-- picks up pluto build version from pom file -->
     <property name="pluto.version" value="${project.version}" description="Version of Pluto to build"/>
 
     <property name="dist.basedir" value="target/dist" description="Base working directory"/>
-    <property name="base.name" value="wildfly-${wildfly.full.version}"/>
+    <property name="base.name" value="payara41"/>
                                      
     <property name="dist.dir" value="${dist.basedir}/${base.name}"/>
     <property name="tck.dir" value="portlet-tck_3.0"/>
-    <property name="pluto.name" value="pluto-wildfly-${pluto.version}"/>
+    <property name="pluto.name" value="pluto-payara-${pluto.version}"/>
     <property name="pluto.tck.name" value="pluto-${pluto.version}-tck"/>
     <property name="pluto.dir" value="${dist.basedir}/${pluto.name}"/>
-    <property name="cache.dir" value="${user.home}/.m2/repository/org/wildfly/dist" />
-    <property name="download.file" value="${cache.dir}/${base.name}.tar.gz" />
+    <property name="cache.dir" value="${user.home}/.m2/repository/fish/payara/dist" />
+    <property name="download.file" value="${cache.dir}/${base.name}.zip" />
     <property name="tar.file" value="${dist.basedir}/${base.name}.tar"/>
 
     <target name="bundle-dist"
             depends="prepare-bundle-dist,run-maven-exclude-demos,run-maven-include-demos,run-dependency-maven-plugin"
             description="Creates zip, gzip, and bzip2 distributions">
+        
         <!-- Copy over jars needed to deploy custom portlets -->
         <!--<copy file="pluto-util/target/pluto-util-${pluto.version}.jar" todir="${dist.dir}/PlutoDomain"/>-->
 
@@ -126,20 +127,21 @@
     </target>
 
     <target name="include-demos" if="includeDemos">
-        <copy file="ChatRoomDemo/target/chatRoomDemo.war" todir="${dist.dir}/standalone/deployments" />
-        <copy file="PortletHubDemo/target/PortletHubDemo.war" todir="${dist.dir}/standalone/deployments" />
-        <copy file="PortletV3Demo/target/PortletV3Demo.war" todir="${dist.dir}/standalone/deployments" />
-        <copy file="PortletV3AnnotatedDemo/target/PortletV3AnnotatedDemo.war" todir="${dist.dir}/standalone/deployments" />
+        <!-- TODO: This does not work yet -->
+        <copy file="ChatRoomDemo/target/chatRoomDemo.war" todir="${dist.dir}/glassfish/domains/domain1/autodeploy" />
+        <copy file="PortletHubDemo/target/PortletHubDemo.war" todir="${dist.dir}/glassfish/domains/domain1/autodeploy" />
+        <copy file="PortletV3Demo/target/PortletV3Demo.war" todir="${dist.dir}/glassfish/domains/domain1/autodeploy" />
+        <copy file="PortletV3AnnotatedDemo/target/PortletV3AnnotatedDemo.war" todir="${dist.dir}/glassfish/domains/domain1/autodeploy" />
     </target>
    
     <target name="tar-nocompress" description="Creates tar bundled distribution">
         <tar destfile="${dist.basedir}/${pluto.name}-bundle.tar">
             <tarfileset prefix="${pluto.name}" dir="${dist.dir}" mode="755" username="pluto" group="pluto">
-                <include name="bin/*.sh"/>
+                <include name="bin/asadmin"/>
             </tarfileset>
             <tarfileset prefix="${pluto.name}" dir="${dist.dir}" username="pluto" group="pluto">
                 <include name="**/*"/>
-                <exclude name="bin/*.sh"/>
+                <exclude name="bin/asadmin"/>
             </tarfileset>
         </tar>      
     </target>
@@ -156,18 +158,12 @@
         <mkdir dir="${dist.basedir}"/>
         <mkdir dir="${cache.dir}" />
         
-        <get src="http://download.jboss.org/wildfly/${wildfly.full.version}/wildfly-${wildfly.full.version}.tar.gz"
+        <get src="https://s3-eu-west-1.amazonaws.com/payara.fish/Payara+Downloads/Payara+${payara.full.version}/payara-${payara.full.version}.zip"
              dest="${download.file}" skipexisting="true" />
 
-        <gunzip src="${download.file}"
-                dest="${dist.basedir}"
-                description="Creates tar from tar.gz wildfly dist"
-                
-        />
-
-        <untar src="${tar.file}"
+        <unzip src="${download.file}"
                dest="${dist.basedir}"
-               description="Untars wildfly dist"
+               description="Unzip payara dist"
         />      
 
         <!-- Copy over README -->
@@ -185,41 +181,8 @@
             </fileset>
         </copy>
 
-        <!-- Add 'pluto' to application-users.properties 
-            ./add-user.sh -a -g pluto pluto pluto (Linux)
-            ./add-user.bat -a -g pluto pluto pluto (Windows)
-        -->
-        <echo append="true" file="${dist.dir}/standalone/configuration/application-users.properties" level="verbose">pluto=de129a3c0a09e04aef0e508490543f14</echo>
-        <echo append="true" file="${dist.dir}/standalone/configuration/application-roles.properties" level="verbose">pluto=pluto</echo>
-        
-        <echo append="true" file="${dist.dir}/standalone/configuration/mgmt-users.properties" level="verbose">pluto=d4ccdb4bbaeb51d98b1d0e3ab4657b88</echo>
-        
-        <!-- Create modules.xml (TODO: Find a better to do this) -->
-        <echo file="${dist.dir}/modules/system/layers/base/org/apache/pluto/main/module.xml" level="verbose">&lt;module xmlns="urn:jboss:module:1.1" name="org.apache.pluto"&gt;
-    &lt;resources&gt;
-        &lt;resource-root path="annotation-detector-3.0.5.jar"/&gt;
-        &lt;resource-root path="ccpp-1.0.jar"/&gt;
-        &lt;resource-root path="pluto-container-${pluto.version}.jar"/&gt;
-        &lt;resource-root path="pluto-container-api-${pluto.version}.jar"/&gt;
-        &lt;resource-root path="pluto-container-driver-api-${pluto.version}.jar"/&gt;
-        &lt;resource-root path="pluto-taglib-${pluto.version}.jar"/&gt;
-        &lt;resource-root path="portlet-api-${pluto.version}.jar"/&gt;
-    &lt;/resources&gt;
-    &lt;dependencies&gt;
-        &lt;module name="javaee.api"/&gt;
-        &lt;module name="org.slf4j"/&gt;
-    &lt;/dependencies&gt;
-&lt;/module&gt;</echo>
-
-        <!-- Add global-modules in standalone.xml -->
-        <replace file='${dist.dir}/standalone/configuration/standalone.xml'
-                 token='&lt;subsystem xmlns="urn:jboss:domain:ee:4.0"&gt;' 
-                 value='&lt;subsystem xmlns="urn:jboss:domain:ee:4.0"&gt;
-            &lt;global-modules&gt;
-                &lt;module name="org.apache.pluto" slot="main"/&gt;
-            &lt;/global-modules&gt;' 
-                 summary='true'
-        />
+        <!-- Add 'pluto' to application users group pluto -->
+        <echo append="true" file="${dist.dir}/glassfish/domains/domain1/config/keyfile" level="verbose">pluto;{SSHA256}BACXmLd2yeXC7FTHDC5Cn5aF81WVYkOK95JjAi5c/KWnj/YfCbZbfg==;pluto</echo>
         
     </target>
    
@@ -259,7 +222,7 @@
 
     <target name="run-dependency-maven-plugin" description="Runs the install goal for the pluto-maven-plugin">
         <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
-           <arg line="-P=wildfly dependency:copy -N -DlibDir=${basedir}/${dist.dir}/modules/system/layers/base/org/apache/pluto/main -DdomainDir=${basedir}/${dist.dir}/standalone/deployments"/>
+           <arg line="-P=payara dependency:copy -N -DlibDir=${basedir}/${dist.dir}/glassfish/domains/domain1/lib -DdomainDir=${basedir}/${dist.dir}/glassfish/domains/domain1/autodeploy/"/>
         </exec>
     </target>
       

--- a/dist-tomee-build.xml
+++ b/dist-tomee-build.xml
@@ -1,0 +1,257 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!--
+   Builds bundled and source distribution of Pluto, archiving it in zip, gzip and bzip2 files.
+   Prerequisites for this build includes an installed Java 5+ JDK, Maven 2.0+ and Ant 1.6+.
+   
+   Run the binary build using the command line:
+      ant -f dist-tomee-build.xml
+
+   Or if you want to include the demo portlet WARs:
+      ant -f dist-tomee-build.xml -DincludeDemos=true
+
+   If you want to package the TCK source & deliverables (warning: produces large files!):
+      ant -f dist-tomee-build.xml -DpackageTck=true
+      
+   If you want to retain the intermediate products (tomcat directory), add the noClean flag:
+      ant -f dist-tomee-build.xml -DincludeDemos=true -DnoClean=true
+      
+   If you want to just package an existing build without cleaning and recompiling first, 
+   add the packageOnly flag:
+      ant -f dist-tomee-build.xml -DincludeDemos=true -DpackageOnly=true
+
+   The bundled distribution is done in the following way:
+   1. Downloads Tomee from Apache and unzips it into a working directory. To this distribution, the
+      build:
+      a. Adds emptySessionPath="true" to server.xml.
+      b. Adds a pluto and tomee users with pluto and manager roles to tomcat-users.xml.
+      c. Adds openejb.scan.webapp.container=true to system.properties (so that CDI scan can pick up pluto)
+      d. Create context files for pluto and testsuite
+   2. Runs 'mvn install' and 'mvn dependency:copy' to create the Pluto driver and testsuite 
+      and installs them into the Tomee dist in the working directory.
+   3. Archives the altered Tomee dist with Pluto into a zip, gzip and bzip2 file.
+   
+   All built distributions end up in target/dist.
+   
+   After unarchiving the built distribution into a directory, invoke the startup script in the bin
+   directory and browse to: http://localhost:8080/pluto/portal/
+   
+   Login as 'pluto' (password=pluto) to the portal. You will need to login again into the manager
+   application linked at the bottom of the Pluto Admin page in order to upload portlet application
+   war files to be able to deploy them to Pluto using the admin portlet. The 'tomee' (password=tomee)
+   user can also be used to deploy portlets.               
+-->
+<project name="PlutoTomeeDistributions" default="bundle-dist">
+
+    <property name="tomee.full.version" value="7.0.3" description="Full version of Tomee to deploy Pluto war files."/>
+
+    <xmlproperty file="pom.xml"/> <!-- picks up pluto build version from pom file -->
+    <property name="pluto.version" value="${project.version}" description="Version of Pluto to build"/>
+
+    <property name="dist.basedir" value="target/dist" description="Base working directory"/>
+    <property name="base.name" value="apache-tomee-plume-${tomee.full.version}"/>
+                                     
+    <property name="dist.dir" value="${dist.basedir}/${base.name}"/>
+    <property name="tck.dir" value="portlet-tck_3.0"/>
+    <property name="pluto.name" value="pluto-tomee-${pluto.version}"/>
+    <property name="pluto.tck.name" value="pluto-${pluto.version}-tck"/>
+    <property name="pluto.dir" value="${dist.basedir}/${pluto.name}"/>
+    <property name="cache.dir" value="${user.home}/.m2/repository/org/apache/tomee/dist" />
+    <property name="download.file" value="${cache.dir}/${base.name}.tar.gz" />
+    <property name="tar.file" value="${dist.basedir}/${base.name}.tar"/>
+
+    <target name="bundle-dist"
+            depends="prepare-bundle-dist,run-maven-exclude-demos,run-maven-include-demos,run-dependency-maven-plugin"
+            description="Creates zip, gzip, and bzip2 distributions">
+        <!-- Copy over jars needed to deploy custom portlets -->
+        <copy file="pluto-util/target/pluto-util-${pluto.version}.jar" todir="${dist.dir}/PlutoDomain"/>         
+
+        <antcall target="include-demos" />
+
+        <!-- Zip everything up -->
+        <zip destfile="${dist.basedir}/${pluto.name}-bundle.zip">
+            <zipfileset prefix="${pluto.name}" dir="${dist.dir}" includes="**/*"/>
+        </zip>
+
+        <antcall target="tar-nocompress"/>
+      
+        <gzip src="${dist.basedir}/${pluto.name}-bundle.tar" 
+              destfile="${dist.basedir}/${pluto.name}-bundle.tar.gz"/>
+      
+        <bzip2 src="${dist.basedir}/${pluto.name}-bundle.tar" 
+               destfile="${dist.basedir}/${pluto.name}-bundle.tar.bz2"/>
+
+        <!-- copy the portlet API jars to the dist directory -->
+        <copy file="portlet-api/target/portlet-api-${pluto.version}.jar" todir="${dist.basedir}"/>         
+        <copy file="portlet-api/target/portlet-api-${pluto.version}-javadoc.jar" todir="${dist.basedir}"/>         
+        <copy file="portlet-api/target/portlet-api-${pluto.version}-sources.jar" todir="${dist.basedir}"/>         
+         
+        <!-- Now package the TCK deliverables -->         
+        <antcall target="package-tck"/>      
+            
+        <antcall target="clean"/>
+    </target>
+
+    <target name="package-tck" if="packageTck">
+        <zip destfile="${dist.basedir}/${pluto.name}-tck.zip">
+            <zipfileset prefix="${pluto.tck.name}" dir="${tck.dir}" includes="**/*"/>
+        </zip>
+
+        <tar destfile="${dist.basedir}/${pluto.name}-tck.tar">
+            <tarfileset prefix="${pluto.name}" dir="${tck.dir}" username="pluto" group="pluto">
+                <include name="**/*"/>
+            </tarfileset>
+        </tar>      
+      
+        <gzip src="${dist.basedir}/${pluto.name}-tck.tar" 
+              destfile="${dist.basedir}/${pluto.name}-tck.tar.gz"/>
+      
+        <bzip2 src="${dist.basedir}/${pluto.name}-tck.tar" 
+               destfile="${dist.basedir}/${pluto.name}-tck.tar.bz2"/>
+
+    </target>
+
+    <target name="include-demos" if="includeDemos">
+        <copy file="ChatRoomDemo/target/chatRoomDemo.war" todir="${dist.dir}/webapps" />
+        <copy file="PortletHubDemo/target/PortletHubDemo.war" todir="${dist.dir}/webapps" />
+        <copy file="PortletV3Demo/target/PortletV3Demo.war" todir="${dist.dir}/webapps" />
+        <copy file="PortletV3AnnotatedDemo/target/PortletV3AnnotatedDemo.war" todir="${dist.dir}/webapps" />
+    </target>
+   
+    <target name="tar-nocompress" description="Creates tar bundled distribution">
+        <tar destfile="${dist.basedir}/${pluto.name}-bundle.tar">
+            <tarfileset prefix="${pluto.name}" dir="${dist.dir}" mode="755" username="pluto" group="pluto">
+                <include name="bin/*.sh"/>
+            </tarfileset>
+            <tarfileset prefix="${pluto.name}" dir="${dist.dir}" username="pluto" group="pluto">
+                <include name="**/*"/>
+                <exclude name="bin/*.sh"/>
+            </tarfileset>
+        </tar>      
+    </target>
+      
+    <!-- convenience to speed up the build -->
+    <target name="preclean" unless="packageOnly">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+            <arg line="clean:clean"/>
+        </exec>
+    </target>
+   
+    <target name="prepare-bundle-dist" depends="preclean">
+        <delete dir="${dist.basedir}" failonerror="false"/>
+        <mkdir dir="${dist.basedir}"/>
+        <mkdir dir="${cache.dir}" />
+        <get src="http://repo.maven.apache.org/maven2/org/apache/tomee/apache-tomee/${tomee.full.version}/apache-tomee-${tomee.full.version}-plume.tar.gz"
+             dest="${download.file}" skipexisting="true" />
+
+        <gunzip src="${download.file}"
+                dest="${dist.basedir}"
+                description="Creates tar from tar.gz tomee dist"
+        />
+
+        <untar src="${tar.file}"
+               dest="${dist.basedir}"
+               description="Untars tomee dist"
+        />      
+
+        <!-- Copy over README -->
+        <copy file="README" todir="${dist.dir}"/>
+
+        <!-- Copy over additional licenses from pluto and testsuite web app-->
+        <copy todir="${dist.dir}" flatten="true">
+            <fileset dir="${basedir}/pluto-testsuite">
+                <include name="src/main/webapp/META-INF/*-LICENSE"/>
+            </fileset>
+        </copy>
+        <copy todir="${dist.dir}" flatten="true">
+            <fileset dir="${basedir}/pluto-portal">
+                <include name="src/main/webapp/META-INF/*-LICENSE"/>
+            </fileset>
+        </copy>
+
+        <!-- Add sessionCookiePath="/" to root Context in context.xml
+        (Tomcat 6.0.27+ replacement for emptySessionPath="true" attribute of Connector element in server.xml) -->
+        <replace file="${dist.dir}/conf/context.xml"
+                 token="&lt;Context&gt;" 
+                 value="&lt;Context sessionCookiePath=&quot;/&quot;&gt;" 
+                 summary="true"
+        />
+      
+        <!-- Make sure the CDI scan files in lib -->
+        <echo file="${dist.dir}/conf/system.properties" append="true" level="verbose">openejb.scan.webapp.container=true</echo>
+      
+        <!-- Add 'pluto' and 'tomee' users to tomcat-users.xml -->
+        <replace file="${dist.dir}/conf/tomcat-users.xml"
+                 token="&lt;/tomcat-users&gt;" 
+                 value="&lt;user username=&quot;tomee&quot; password=&quot;tomee&quot; roles=&quot;tomee-admin,pluto,manager-gui&quot; /&gt;${line.separator}&lt;user username=&quot;pluto&quot; password=&quot;pluto&quot; roles=&quot;pluto,manager-gui,tckuser&quot; /&gt;${line.separator}&lt;/tomcat-users&gt;" 
+                 summary="true"
+        />
+        
+        <!-- Set the context for pluto and testsuite -->
+        <echo file="${dist.dir}/conf/Catalina/localhost/pluto.xml" level="verbose">&lt;Context path="/pluto" docBase="../PlutoDomain/pluto-portal-${pluto.version}.war" crossContext="true"&gt;&lt;/Context&gt;</echo>
+        <echo file="${dist.dir}/conf/Catalina/localhost/testsuite.xml" level="verbose">&lt;Context path="/testsuite" docBase="../PlutoDomain/pluto-testsuite-${pluto.version}.war" crossContext="true"&gt;&lt;/Context&gt;</echo>
+        
+    </target>
+   
+    <!-- Only do mvn install if 'packageOnly' is not set -->
+    <condition property="installDemos">
+        <and>
+            <equals casesensitive="false" arg1="${includeDemos}" arg2="true"/>
+            <not>
+                <equals casesensitive="false" arg1="${packageOnly}" arg2="true"/>
+            </not>
+        </and>
+    </condition>
+   
+    <!-- Only do mvn install if 'packageOnly' is not set -->
+    <condition property="installNoDemos">
+        <and>
+            <not>
+                <equals casesensitive="false" arg1="${includeDemos}" arg2="true"/>
+            </not>
+            <not>
+                <equals casesensitive="false" arg1="${packageOnly}" arg2="true"/>
+            </not>
+        </and>
+    </condition>
+
+    <target name="run-maven-exclude-demos" if="installNoDemos" description="Runs the install goal and excludes the demos from pluto-portal-driver-config.xml">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+            <arg line="install -Ppluto,excludeDemos -DskipTests=true"/>
+        </exec>
+    </target>
+
+    <target name="run-maven-include-demos" if="installDemos" description="Runs the install goal and includes the demos in pluto-portal-driver-config.xml">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+            <arg line="install -Ppluto -DskipTests=true"/>
+        </exec>
+    </target>
+
+    <target name="run-dependency-maven-plugin" description="Runs the install goal for the pluto-maven-plugin">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+           <arg line="-P=tomee dependency:copy -N -DlibDir=${basedir}/${dist.dir}/lib -DdomainDir=${basedir}/${dist.dir}/PlutoDomain"/>
+        </exec>
+    </target>
+      
+    <target name="clean" unless="noClean">
+        <delete dir="${dist.dir}"/>
+        <delete file="${tar.file}"/>   
+    </target>
+
+</project>

--- a/dist-wildfly-build.xml
+++ b/dist-wildfly-build.xml
@@ -1,0 +1,271 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!--
+   Builds bundled and source distribution of Pluto, archiving it in zip, gzip and bzip2 files.
+   Prerequisites for this build includes an installed Java 5+ JDK, Maven 2.0+ and Ant 1.6+.
+   
+   Run the binary build using the command line:
+      ant -f dist-wildfly-build.xml
+
+   Or if you want to include the demo portlet WARs:
+      ant -f dist-wildfly-build.xml -DincludeDemos=true
+
+   If you want to package the TCK source & deliverables (warning: produces large files!):
+      ant -f dist-wildfly-build.xml -DpackageTck=true
+      
+   If you want to retain the intermediate products (tomcat directory), add the noClean flag:
+      ant -f dist-wildfly-build.xml -DincludeDemos=true -DnoClean=true
+      
+   If you want to just package an existing build without cleaning and recompiling first, 
+   add the packageOnly flag:
+      ant -f dist-wildfly-build.xml -DincludeDemos=true -DpackageOnly=true
+
+   The bundled distribution is done in the following way:
+   1. Downloads wildfly and unzips it into a working directory. To this distribution, the
+      build:
+      a. Adds a pluto user with pluto to application users
+      b. Create module.xml files for pluto dependencies
+      c. Add pluto in global-modules in standalone.xml
+   2. Runs 'mvn install' and 'mvn dependency:copy' to create the Pluto driver and testsuite 
+      and installs them into the Tomee dist in the working directory.
+   3. Archives the altered Wildfly dist with Pluto into a zip, gzip and bzip2 file.
+   
+   All built distributions end up in target/dist.
+   
+   After unarchiving the built distribution into a directory, invoke the standalone startup script in the bin
+   directory and browse to: http://localhost:8080/pluto/portal/
+   
+   Login as 'pluto' (password=pluto) to the portal. You will need to login again into the manager
+   application linked at the bottom of the Pluto Admin page in order to upload portlet application
+   war files to be able to deploy them to Pluto using the admin portlet. 
+-->
+<project name="PlutoWildflyDistributions" default="bundle-dist">
+
+    <property name="wildfly.full.version" value="10.1.0.Final" description="Full version of Wildfly to deploy Pluto war files."/>
+
+    <xmlproperty file="pom.xml"/> <!-- picks up pluto build version from pom file -->
+    <property name="pluto.version" value="${project.version}" description="Version of Pluto to build"/>
+
+    <property name="dist.basedir" value="target/dist" description="Base working directory"/>
+    <property name="base.name" value="wildfly-${wildfly.full.version}"/>
+                                     
+    <property name="dist.dir" value="${dist.basedir}/${base.name}"/>
+    <property name="tck.dir" value="portlet-tck_3.0"/>
+    <property name="pluto.name" value="pluto-wildfly-${pluto.version}"/>
+    <property name="pluto.tck.name" value="pluto-${pluto.version}-tck"/>
+    <property name="pluto.dir" value="${dist.basedir}/${pluto.name}"/>
+    <property name="cache.dir" value="${user.home}/.m2/repository/org/wildfly/dist" />
+    <property name="download.file" value="${cache.dir}/${base.name}.tar.gz" />
+    <property name="tar.file" value="${dist.basedir}/${base.name}.tar"/>
+
+    <target name="bundle-dist"
+            depends="prepare-bundle-dist,run-maven-exclude-demos,run-maven-include-demos,run-dependency-maven-plugin"
+            description="Creates zip, gzip, and bzip2 distributions">
+        <!-- Copy over jars needed to deploy custom portlets -->
+        <copy file="pluto-util/target/pluto-util-${pluto.version}.jar" todir="${dist.dir}/PlutoDomain"/>         
+
+        <antcall target="include-demos" />
+
+        <!-- Zip everything up -->
+        <zip destfile="${dist.basedir}/${pluto.name}-bundle.zip">
+            <zipfileset prefix="${pluto.name}" dir="${dist.dir}" includes="**/*" />
+        </zip>
+
+        <antcall target="tar-nocompress"/>
+      
+        <gzip src="${dist.basedir}/${pluto.name}-bundle.tar" 
+              destfile="${dist.basedir}/${pluto.name}-bundle.tar.gz"/>
+      
+        <bzip2 src="${dist.basedir}/${pluto.name}-bundle.tar" 
+               destfile="${dist.basedir}/${pluto.name}-bundle.tar.bz2"/>
+
+        <!-- copy the portlet API jars to the dist directory -->
+        <copy file="portlet-api/target/portlet-api-${pluto.version}.jar" todir="${dist.basedir}"/>         
+        <copy file="portlet-api/target/portlet-api-${pluto.version}-javadoc.jar" todir="${dist.basedir}"/>         
+        <copy file="portlet-api/target/portlet-api-${pluto.version}-sources.jar" todir="${dist.basedir}"/>         
+         
+        <!-- Now package the TCK deliverables -->         
+        <antcall target="package-tck"/>      
+            
+        <antcall target="clean"/>
+    </target>
+
+    <target name="package-tck" if="packageTck">
+        <zip destfile="${dist.basedir}/${pluto.name}-tck.zip">
+            <zipfileset prefix="${pluto.tck.name}" dir="${tck.dir}" includes="**/*"/>
+        </zip>
+
+        <tar destfile="${dist.basedir}/${pluto.name}-tck.tar">
+            <tarfileset prefix="${pluto.name}" dir="${tck.dir}" username="pluto" group="pluto">
+                <include name="**/*"/>
+            </tarfileset>
+        </tar>      
+      
+        <gzip src="${dist.basedir}/${pluto.name}-tck.tar" 
+              destfile="${dist.basedir}/${pluto.name}-tck.tar.gz"/>
+      
+        <bzip2 src="${dist.basedir}/${pluto.name}-tck.tar" 
+               destfile="${dist.basedir}/${pluto.name}-tck.tar.bz2"/>
+
+    </target>
+
+    <target name="include-demos" if="includeDemos">
+        <copy file="ChatRoomDemo/target/chatRoomDemo.war" todir="${dist.dir}/standalone/deployments" />
+        <copy file="PortletHubDemo/target/PortletHubDemo.war" todir="${dist.dir}/standalone/deployments" />
+        <copy file="PortletV3Demo/target/PortletV3Demo.war" todir="${dist.dir}/standalone/deployments" />
+        <copy file="PortletV3AnnotatedDemo/target/PortletV3AnnotatedDemo.war" todir="${dist.dir}/standalone/deployments" />
+    </target>
+   
+    <target name="tar-nocompress" description="Creates tar bundled distribution">
+        <tar destfile="${dist.basedir}/${pluto.name}-bundle.tar">
+            <tarfileset prefix="${pluto.name}" dir="${dist.dir}" mode="755" username="pluto" group="pluto">
+                <include name="bin/*.sh"/>
+            </tarfileset>
+            <tarfileset prefix="${pluto.name}" dir="${dist.dir}" username="pluto" group="pluto">
+                <include name="**/*"/>
+                <exclude name="bin/*.sh"/>
+            </tarfileset>
+        </tar>      
+    </target>
+      
+    <!-- convenience to speed up the build -->
+    <target name="preclean" unless="packageOnly">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+            <arg line="clean:clean"/>
+        </exec>
+    </target>
+   
+    <target name="prepare-bundle-dist" depends="preclean">
+        <delete dir="${dist.basedir}" failonerror="false"/>
+        <mkdir dir="${dist.basedir}"/>
+        <mkdir dir="${cache.dir}" />
+        
+        <get src="http://download.jboss.org/wildfly/${wildfly.full.version}/wildfly-${wildfly.full.version}.tar.gz"
+             dest="${download.file}" skipexisting="true" />
+
+        <gunzip src="${download.file}"
+                dest="${dist.basedir}"
+                description="Creates tar from tar.gz wildfly dist"
+                
+        />
+
+        <untar src="${tar.file}"
+               dest="${dist.basedir}"
+               description="Untars wildfly dist"
+        />      
+
+        <!-- Copy over README -->
+        <copy file="README" todir="${dist.dir}"/>
+
+        <!-- Copy over additional licenses from pluto and testsuite web app-->
+        <copy todir="${dist.dir}" flatten="true">
+            <fileset dir="${basedir}/pluto-testsuite">
+                <include name="src/main/webapp/META-INF/*-LICENSE"/>
+            </fileset>
+        </copy>
+        <copy todir="${dist.dir}" flatten="true">
+            <fileset dir="${basedir}/pluto-portal">
+                <include name="src/main/webapp/META-INF/*-LICENSE"/>
+            </fileset>
+        </copy>
+
+        <!-- Add 'pluto' to application-users.properties 
+            ./add-user.sh -a -g pluto pluto pluto (Linux)
+            ./add-user.bat -a -g pluto pluto pluto (Windows)
+        -->
+        <echo append="true" file="${dist.dir}/standalone/configuration/application-users.properties" level="verbose">pluto=de129a3c0a09e04aef0e508490543f14</echo>
+        <echo append="true" file="${dist.dir}/standalone/configuration/application-roles.properties" level="verbose">pluto=pluto</echo>
+        
+        <echo append="true" file="${dist.dir}/standalone/configuration/mgmt-users.properties" level="verbose">pluto=d4ccdb4bbaeb51d98b1d0e3ab4657b88</echo>
+        
+        <!-- Create modules.xml (TODO: Find a better to do this) -->
+        <echo file="${dist.dir}/modules/system/layers/base/org/apache/pluto/main/module.xml" level="verbose">&lt;module xmlns="urn:jboss:module:1.1" name="org.apache.pluto"&gt;
+    &lt;resources&gt;
+        &lt;resource-root path="annotation-detector-3.0.5.jar"/&gt;
+        &lt;resource-root path="ccpp-1.0.jar"/&gt;
+        &lt;resource-root path="pluto-container-${pluto.version}.jar"/&gt;
+        &lt;resource-root path="pluto-container-api-${pluto.version}.jar"/&gt;
+        &lt;resource-root path="pluto-container-driver-api-${pluto.version}.jar"/&gt;
+        &lt;resource-root path="pluto-taglib-${pluto.version}.jar"/&gt;
+        &lt;resource-root path="portlet-api-${pluto.version}.jar"/&gt;
+    &lt;/resources&gt;
+    &lt;dependencies&gt;
+        &lt;module name="javaee.api"/&gt;
+        &lt;module name="org.slf4j"/&gt;
+    &lt;/dependencies&gt;
+&lt;/module&gt;</echo>
+
+        <!-- Add global-modules in standalone.xml -->
+        <replace file='${dist.dir}/standalone/configuration/standalone.xml'
+                 token='&lt;subsystem xmlns="urn:jboss:domain:ee:4.0"&gt;' 
+                 value='&lt;subsystem xmlns="urn:jboss:domain:ee:4.0"&gt;
+            &lt;global-modules&gt;
+                &lt;module name="org.apache.pluto" slot="main"/&gt;
+            &lt;/global-modules&gt;' 
+                 summary='true'
+        />
+        
+    </target>
+   
+    <!-- Only do mvn install if 'packageOnly' is not set -->
+    <condition property="installDemos">
+        <and>
+            <equals casesensitive="false" arg1="${includeDemos}" arg2="true"/>
+            <not>
+                <equals casesensitive="false" arg1="${packageOnly}" arg2="true"/>
+            </not>
+        </and>
+    </condition>
+   
+    <!-- Only do mvn install if 'packageOnly' is not set -->
+    <condition property="installNoDemos">
+        <and>
+            <not>
+                <equals casesensitive="false" arg1="${includeDemos}" arg2="true"/>
+            </not>
+            <not>
+                <equals casesensitive="false" arg1="${packageOnly}" arg2="true"/>
+            </not>
+        </and>
+    </condition>
+
+    <target name="run-maven-exclude-demos" if="installNoDemos" description="Runs the install goal and excludes the demos from pluto-portal-driver-config.xml">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+            <arg line="install -Ppluto,excludeDemos -DskipTests=true"/>
+        </exec>
+    </target>
+
+    <target name="run-maven-include-demos" if="installDemos" description="Runs the install goal and includes the demos in pluto-portal-driver-config.xml">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+            <arg line="install -Ppluto -DskipTests=true"/>
+        </exec>
+    </target>
+
+    <target name="run-dependency-maven-plugin" description="Runs the install goal for the pluto-maven-plugin">
+        <exec executable="mvn" vmlauncher="false" dir="${basedir}" failonerror="true">
+           <arg line="-P=wildfly dependency:copy -N -DlibDir=${basedir}/${dist.dir}/modules/system/layers/base/org/apache/pluto/main -DdomainDir=${basedir}/${dist.dir}/standalone/deployments"/>
+        </exec>
+    </target>
+      
+    <target name="clean" unless="noClean">
+        <delete dir="${dist.dir}"/>
+        <delete file="${tar.file}"/>   
+    </target>
+
+</project>

--- a/pluto-portal/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/pluto-portal/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glassfish-web-app>
+    <context-root>/pluto</context-root>
+</glassfish-web-app>

--- a/pluto-portal/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/pluto-portal/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+    <context-root>/pluto</context-root>
+</jboss-web>

--- a/pluto-testsuite/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/pluto-testsuite/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glassfish-web-app>
+    <context-root>/testsuite</context-root>
+</glassfish-web-app>

--- a/pluto-testsuite/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/pluto-testsuite/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+    <context-root>/testsuite</context-root>
+</jboss-web>

--- a/pom.xml
+++ b/pom.xml
@@ -921,6 +921,118 @@ generate mailto links. -->
             </build>
         </profile>
 
+        <!-- To build Pluto for deployment on payara, activate this profile -->
+        <!-- Activate using the payara property: mvn clean install -Dpayara -->
+        <profile>
+            <id>payara</id>
+            <activation>
+                <property>
+                    <name>payara</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- scope of certain dependencies is "compile" for deployment on tomcat, 
+                but "provided" for deployment on payara. See wildfly profile. -->
+                <!-- TODO: This might have to change to a per dependency property -->
+                <dependency.scope>provided</dependency.scope>
+            </properties>
+      
+            <!-- The artifacts needed for wildfly -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+
+                        <configuration>
+                            <excludeScope>test</excludeScope>
+                            <excludeScope>compile</excludeScope>
+
+                            <artifactItems>
+                                <!-- The Spec -->
+                                <artifactItem>
+                                    <groupId>javax.portlet</groupId>
+                                    <artifactId>portlet-api</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                
+                                <!-- Pluto Implementation -->
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container-api</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container-driver-api</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-taglib</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <!-- Pluto portal wars -->
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-portal</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${domainDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-testsuite</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${domainDir}</outputDirectory>
+                                </artifactItem>
+                                    
+                                <!-- 3rd Party Libraries -->
+                                <artifactItem>
+                                    <groupId>eu.infomas</groupId>
+                                    <artifactId>annotation-detector</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>    
+                                <artifactItem>
+                                    <groupId>javax.ccpp</groupId>
+                                    <artifactId>ccpp</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>slf4j-api</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.slf4j</groupId>
+                                    <artifactId>slf4j-jdk14</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -819,6 +819,109 @@ generate mailto links. -->
             </build>
         </profile>
 
+        <!-- To build Pluto for deployment on wildfly, activate this profile -->
+        <!-- Activate using the wildfly property: mvn clean install -Dwildfly -->
+        <profile>
+            <id>wildfly</id>
+            <activation>
+                <property>
+                    <name>wildfly</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- scope of certain dependencies is "compile" for deployment on tomcat, 
+                but "provided" for deployment on wildfly. See wildfly profile. -->
+                <!-- TODO: This might have to change to a per dependency property -->
+                <dependency.scope>provided</dependency.scope>
+            </properties>
+      
+            <!-- The artifacts needed for wildfly -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+
+                        <configuration>
+                            <excludeScope>test</excludeScope>
+                            <excludeScope>compile</excludeScope>
+
+                            <artifactItems>
+                                <!-- The Spec -->
+                                <artifactItem>
+                                    <groupId>javax.portlet</groupId>
+                                    <artifactId>portlet-api</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                
+                                <!-- Pluto Implementation -->
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container-api</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container-driver-api</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-taglib</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <!-- Pluto portal wars -->
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-portal</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${domainDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-testsuite</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${domainDir}</outputDirectory>
+                                </artifactItem>
+                                    
+                                <!-- 3rd Party Libraries -->
+                                <artifactItem>
+                                    <groupId>eu.infomas</groupId>
+                                    <artifactId>annotation-detector</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>    
+                                <artifactItem>
+                                    <groupId>javax.ccpp</groupId>
+                                    <artifactId>ccpp</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                       
+                            </artifactItems>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -258,482 +258,567 @@ generate mailto links. -->
   <!--
   NOTE:
 
-  Modification of these properties affects:
-  1)  pluto-maven-plugin/src/main/resources/versions.properties as well!
-  -->
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    Modification of these properties affects:
+    1)  pluto-maven-plugin/src/main/resources/versions.properties as well!
+    -->
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <pluto.container.name>Pluto</pluto.container.name>
-    <javax.portlet.version.major>3</javax.portlet.version.major>
-    <javax.portlet.version.minor>0</javax.portlet.version.minor>
-    <portals.portlet-api.version>${project.version}</portals.portlet-api.version>
-    <servlet-api.version>8.0.28</servlet-api.version>
-    <jsp-api.version>8.0.28</jsp-api.version>
-    <jstl.version>8.0.28</jstl.version>
-    <el-api.version>8.0.28</el-api.version>
-    <taglibs.standard.version>1.2.1</taglibs.standard.version>
-    <jaxb.version>2.1</jaxb.version>
-    <jaxb-impl.version>2.1.9</jaxb-impl.version>
-    <stax.impl.version>1.2.0</stax.impl.version>
-    <commons-digester.version>1.8</commons-digester.version>
-    <commons-cli.version>1.0</commons-cli.version>
-    <slf4j.version>1.7.5</slf4j.version>
-    <springframework.version>2.0.2</springframework.version>
-<!--     <springframework.version>4.2.3.RELEASE</springframework.version> -->
-    <maven.version>2.0.5</maven.version>
-    <ant.version>1.6.5</ant.version>
-    <commons-lang.version>3.4</commons-lang.version>
-    <commons-io.version>2.4</commons-io.version>
-    <ccpp-api.version>1.0</ccpp-api.version>
-    <junit.version>4.12</junit.version>
-    <jmock.version>1.2.0</jmock.version>
-    <xmlunit.version>1.1</xmlunit.version>
-    <cdi.version>2.3.1.Final</cdi.version>
-    <annotation-detector.version>3.0.5</annotation-detector.version>
+        <pluto.container.name>Pluto</pluto.container.name>
+        <javax.portlet.version.major>3</javax.portlet.version.major>
+        <javax.portlet.version.minor>0</javax.portlet.version.minor>
+        <portals.portlet-api.version>${project.version}</portals.portlet-api.version>
+        <servlet-api.version>8.0.28</servlet-api.version>
+        <jsp-api.version>8.0.28</jsp-api.version>
+        <jstl.version>8.0.28</jstl.version>
+        <el-api.version>8.0.28</el-api.version>
+        <taglibs.standard.version>1.2.1</taglibs.standard.version>
+        <jaxb.version>2.1</jaxb.version>
+        <jaxb-impl.version>2.1.9</jaxb-impl.version>
+        <stax.impl.version>1.2.0</stax.impl.version>
+        <commons-digester.version>1.8</commons-digester.version>
+        <commons-cli.version>1.0</commons-cli.version>
+        <slf4j.version>1.7.5</slf4j.version>
+        <springframework.version>2.0.2</springframework.version>
+        <!--     <springframework.version>4.2.3.RELEASE</springframework.version> -->
+        <maven.version>2.0.5</maven.version>
+        <ant.version>1.6.5</ant.version>
+        <commons-lang.version>3.4</commons-lang.version>
+        <commons-io.version>2.4</commons-io.version>
+        <ccpp-api.version>1.0</ccpp-api.version>
+        <junit.version>4.12</junit.version>
+        <jmock.version>1.2.0</jmock.version>
+        <xmlunit.version>1.1</xmlunit.version>
+        <cdi.version>2.3.1.Final</cdi.version>
+        <annotation-detector.version>3.0.5</annotation-detector.version>
 
-    <!-- The following properties are not directly used as maven
-dependencies, they're used by the maven pluto plugin for
-handling installation dependencies
-TODO: Check if we need all of them. -->
-    <xerces.version>2.6.2</xerces.version>
-    <xalan.version>2.7.0</xalan.version>
-    <castor.version>1.1.1</castor.version>
-    <commons-collections.version>3.2</commons-collections.version>
-    <commons-httpclient.version>3.0</commons-httpclient.version>
-    <commons-beanutils.version>1.7.0</commons-beanutils.version>
-    <log4j.version>1.2.14</log4j.version>
-    <activation.version>1.1</activation.version>
-    <ccpp-ri.version>1.0</ccpp-ri.version>
-    <rdffilter.version>1.0</rdffilter.version>
-    <jena.version>1.4.0</jena.version>
+        <!-- The following properties are not directly used as maven
+        dependencies, they're used by the maven pluto plugin for
+        handling installation dependencies
+        TODO: Check if we need all of them. -->
+        <xerces.version>2.6.2</xerces.version>
+        <xalan.version>2.7.0</xalan.version>
+        <castor.version>1.1.1</castor.version>
+        <commons-collections.version>3.2</commons-collections.version>
+        <commons-httpclient.version>3.0</commons-httpclient.version>
+        <commons-beanutils.version>1.7.0</commons-beanutils.version>
+        <log4j.version>1.2.14</log4j.version>
+        <activation.version>1.1</activation.version>
+        <ccpp-ri.version>1.0</ccpp-ri.version>
+        <rdffilter.version>1.0</rdffilter.version>
+        <jena.version>1.4.0</jena.version>
 
-    <!-- scope of certain dependencies is "compile" for deployment on tomcat, 
-         but "provided" for deployment on tomee. See tomee profile. -->
-    <dependency.scope>compile</dependency.scope>
+        <!-- scope of certain dependencies is "compile" for deployment on tomcat, 
+        but "provided" for deployment on tomee. See tomee profile. -->
+        <dependency.scope>compile</dependency.scope>
     
-    <!-- following properties control whether or not demos are included in page 
-         config file (see profile 'excludeDemos' below) -->
-    <includeDemosBegin />
-	 <includeDemosEnd />
-  </properties>
+        <!-- following properties control whether or not demos are included in page 
+        config file (see profile 'excludeDemos' below) -->
+        <includeDemosBegin />
+        <includeDemosEnd />
+    </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <!-- Logging =========================================== -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-jdk14</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Logging =========================================== -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
 
-      <!-- Specification Libraries =========================================== -->
-      <dependency>
-         <groupId>javax.portlet</groupId>
-         <artifactId>portlet-api</artifactId>
-         <version>${project.version}</version>
-         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-servlet-api</artifactId>
-        <version>${servlet-api.version}</version>
-      </dependency>
+            <!-- Specification Libraries =========================================== -->
+            <dependency>
+                <groupId>javax.portlet</groupId>
+                <artifactId>portlet-api</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-servlet-api</artifactId>
+                <version>${servlet-api.version}</version>
+            </dependency>
 
-      <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>${jaxb.version}</version>
-      </dependency>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
 
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>${jaxb-impl.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>stax</groupId>
-        <artifactId>stax</artifactId>
-        <version>${stax.impl.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>stax</groupId>
-            <artifactId>stax-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb-impl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>stax</groupId>
+                <artifactId>stax</artifactId>
+                <version>${stax.impl.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>stax</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
       
-      <!-- CDI Library -->
-      <dependency>
-         <groupId>javax.enterprise</groupId>
-         <artifactId>cdi-api</artifactId>
-         <version>1.2</version>
-      </dependency>
-      <dependency>
-          <groupId>org.jboss.weld.servlet</groupId>
-          <artifactId>weld-servlet</artifactId>
-          <version>${cdi.version}</version>
-      </dependency>      
+            <!-- CDI Library -->
+            <dependency>
+                <groupId>javax.enterprise</groupId>
+                <artifactId>cdi-api</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.weld.servlet</groupId>
+                <artifactId>weld-servlet</artifactId>
+                <version>${cdi.version}</version>
+            </dependency>      
 
-      <!-- For method annotation scanning ==================================== -->
-      <dependency>
-         <groupId>eu.infomas</groupId>
-         <artifactId>annotation-detector</artifactId>
-         <version>${annotation-detector.version}</version>
-      </dependency>
+            <!-- For method annotation scanning ==================================== -->
+            <dependency>
+                <groupId>eu.infomas</groupId>
+                <artifactId>annotation-detector</artifactId>
+                <version>${annotation-detector.version}</version>
+            </dependency>
 
-      <!--  CCPP Libraries -->
-      <dependency>
-        <groupId>javax.ccpp</groupId>
-        <artifactId>ccpp</artifactId>
-        <version>${ccpp-api.version}</version>
-      </dependency>
+            <!--  CCPP Libraries -->
+            <dependency>
+                <groupId>javax.ccpp</groupId>
+                <artifactId>ccpp</artifactId>
+                <version>${ccpp-api.version}</version>
+            </dependency>
 
-      <!-- Testing Libraries ================================================= -->
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>jmock</groupId>
-        <artifactId>jmock</artifactId>
-        <version>${jmock.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>jmock</groupId>
-        <artifactId>jmock-cglib</artifactId>
-        <version>${jmock.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>xmlunit</groupId>
-        <artifactId>xmlunit</artifactId>
-        <version>${xmlunit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <!-- Misc ================================================= -->
-      <dependency>
-        <groupId>ant</groupId>
-        <artifactId>ant</artifactId>
-        <version>${ant.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-core</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-artifact</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-model</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-project</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-plugin-api</artifactId>
-        <version>${maven.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-jsp-api</artifactId>
-        <version>${jsp-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat</groupId>
-        <artifactId>tomcat-el-api</artifactId>
-        <version>${el-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.taglibs</groupId>
-        <artifactId>taglibs-standard-spec</artifactId>
-        <version>${taglibs.standard.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.taglibs</groupId>
-        <artifactId>taglibs-standard-impl</artifactId>
-        <version>${taglibs.standard.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.taglibs</groupId>
-        <artifactId>taglibs-standard-jstlel</artifactId>
-        <version>${taglibs.standard.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-        <version>${springframework.version}</version>
-        <scope>compile</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-beans</artifactId>
-        <version>${springframework.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>${springframework.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons-lang.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-digester</groupId>
-        <artifactId>commons-digester</artifactId>
-        <version>${commons-digester.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>commons-cli</groupId>
-        <artifactId>commons-cli</artifactId>
-        <version>${commons-cli.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+            <!-- Testing Libraries ================================================= -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>jmock</groupId>
+                <artifactId>jmock</artifactId>
+                <version>${jmock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>jmock</groupId>
+                <artifactId>jmock-cglib</artifactId>
+                <version>${jmock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>xmlunit</groupId>
+                <artifactId>xmlunit</artifactId>
+                <version>${xmlunit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- Misc ================================================= -->
+            <dependency>
+                <groupId>ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>${ant.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-model</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-project</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-jsp-api</artifactId>
+                <version>${jsp-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-el-api</artifactId>
+                <version>${el-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-spec</artifactId>
+                <version>${taglibs.standard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-impl</artifactId>
+                <version>${taglibs.standard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-jstlel</artifactId>
+                <version>${taglibs.standard.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${springframework.version}</version>
+                <scope>compile</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${springframework.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${springframework.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-digester</groupId>
+                <artifactId>commons-digester</artifactId>
+                <version>${commons-digester.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>${commons-cli.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.portals.pluto</groupId>
-          <artifactId>pluto-maven-plugin</artifactId>
-          <version>${project.version}</version>
-        </plugin>
-        <plugin>
-           <groupId>org.apache.maven.plugins</groupId>
-           <artifactId>maven-jar-plugin</artifactId>
-           <version>2.4</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-war-plugin</artifactId>
-          <version>2.4</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.rat</groupId>
-          <artifactId>apache-rat-plugin</artifactId>
-          <version>0.12</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.7</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
-          <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.2.0</version>
-          <extensions>true</extensions>
-          <configuration>
-            <instructions>
-              <Implementation-Title>${project.name}</Implementation-Title>
-              <Specification-Version>${project.version}</Specification-Version>
-              <Implementation-Version>${project.version}</Implementation-Version>
-              <Bundle-DocURL>${project.url}</Bundle-DocURL>
-            </instructions>
-          </configuration>
-        </plugin>
-        <plugin>
-           <groupId>org.apache.maven.scm</groupId>
-           <artifactId>maven-scm-providers-git</artifactId>
-           <!-- http://jira.codehaus.org/browse/SCM-444 -->
-           <version>(,1.4]</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <configuration>
-            <!-- During release (prepare) the org.apache.felix maven-bundle-plugin needs classpath access to just build dependent artifacts
-                 like the pluto-container-api to determine the needed OSGi imports.
-                 However, the default maven-release-plugin goals (clean verify) somehow don't provide those.
-                 To fix that, the default release plugin set of preparationGoals is changed to do an "install" instead of just "verify".
-            -->
-            <preparationGoals>clean install</preparationGoals>
-            <mavenExecutorId>forked-path</mavenExecutorId>
-            <autoVersionSubmodules>true</autoVersionSubmodules>
-            <pushChanges>false</pushChanges>
-            <localCheckout>true</localCheckout>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.portals.pluto</groupId>
+                    <artifactId>pluto-maven-plugin</artifactId>
+                    <version>${project.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.rat</groupId>
+                    <artifactId>apache-rat-plugin</artifactId>
+                    <version>0.12</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.7</source>
+                        <target>1.7</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <instructions>
+                            <Implementation-Title>${project.name}</Implementation-Title>
+                            <Specification-Version>${project.version}</Specification-Version>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                            <Bundle-DocURL>${project.url}</Bundle-DocURL>
+                        </instructions>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.scm</groupId>
+                    <artifactId>maven-scm-providers-git</artifactId>
+                    <!-- http://jira.codehaus.org/browse/SCM-444 -->
+                    <version>(,1.4]</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <configuration>
+                        <!-- During release (prepare) the org.apache.felix maven-bundle-plugin needs classpath access to just build dependent artifacts
+                             like the pluto-container-api to determine the needed OSGi imports.
+                             However, the default maven-release-plugin goals (clean verify) somehow don't provide those.
+                             To fix that, the default release plugin set of preparationGoals is changed to do an "install" instead of just "verify".
+                        -->
+                        <preparationGoals>clean install</preparationGoals>
+                        <mavenExecutorId>forked-path</mavenExecutorId>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <pushChanges>false</pushChanges>
+                        <localCheckout>true</localCheckout>
             
-            <!-- by default, the release build includes the V3 demos. To perform the release build without the demos, 
-                 activate the 'excludeDemos profile 'arguments' line as shown below. -->
-            <!--
-            <arguments>-Ppluto,excludeDemos</arguments>
-            -->
-            <arguments>-Ppluto</arguments>
-          </configuration>
-        </plugin>
+                        <!-- by default, the release build includes the V3 demos. To perform the release build without the demos, 
+                        activate the 'excludeDemos profile 'arguments' line as shown below. -->
+                        <!--
+                        <arguments>-Ppluto,excludeDemos</arguments>
+                        -->
+                        <arguments>-Ppluto</arguments>
+                    </configuration>
+                </plugin>
 
-			<!-- Javascript compressor plugin -->
-			<plugin>
-				<groupId>net.alchim31.maven</groupId>
-				<artifactId>yuicompressor-maven-plugin</artifactId>
-				<version>1.1</version>
-				<executions>
-					<execution>
-						<id>compress-js</id>
-						<goals>
-							<goal>compress</goal>
-						</goals>
-						<configuration>
-							<jswarn>false</jswarn>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-      </plugins>
-    </pluginManagement>
+                <!-- Javascript compressor plugin -->
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>yuicompressor-maven-plugin</artifactId>
+                    <version>1.1</version>
+                    <executions>
+                        <execution>
+                            <id>compress-js</id>
+                            <goals>
+                                <goal>compress</goal>
+                            </goals>
+                            <configuration>
+                                <jswarn>false</jswarn>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
-  <profiles>
-    <profile>
-      <id>all</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-        <!-- profile must also be activated when building for tomee -->
-        <property>
-          <name>tomee</name>
-        </property>
-      </activation>
+    <profiles>
+        <profile>
+            <id>all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <!-- profile must also be activated when building for tomee -->
+                <property>
+                    <name>tomee</name>
+                </property>
+            </activation>
       
-      <!-- Pluto Modules ======================================================= -->
-      <modules>
-        <!-- Portlet API module (spec -->
-        <module>portlet-api</module>
+            <!-- Pluto Modules ======================================================= -->
+            <modules>
+                <!-- Portlet API module (spec -->
+                <module>portlet-api</module>
 
-        <!-- Pluto Container API -->
-        <module>pluto-container-api</module>
+                <!-- Pluto Container API -->
+                <module>pluto-container-api</module>
 
-        <!-- Pluto Core Modules -->
-        <module>pluto-container</module>
-        <module>pluto-taglib</module>
+                <!-- Pluto Core Modules -->
+                <module>pluto-container</module>
+                <module>pluto-taglib</module>
 
-        <!-- Pluto Portal and Testsuite Modules -->
-        <module>pluto-container-driver-api</module>
-        <module>pluto-portal-driver</module>
-        <module>pluto-portal-driver-impl</module>
-        <module>pluto-portal</module>
-        <module>pluto-testsuite</module>
+                <!-- Pluto Portal and Testsuite Modules -->
+                <module>pluto-container-driver-api</module>
+                <module>pluto-portal-driver</module>
+                <module>pluto-portal-driver-impl</module>
+                <module>pluto-portal</module>
+                <module>pluto-testsuite</module>
 
-        <!-- Aggregated common jar for shared library location -->
-        <module>pluto-common</module>
+                <!-- Aggregated common jar for shared library location -->
+                <module>pluto-common</module>
         
-        <!-- PortletHub demo portlets -->
-        <module>ChatRoomDemo</module>
-        <module>PortletHubDemo</module>
-        <module>PortletV3Demo</module>
-        <module>PortletV3AnnotatedDemo</module>
+                <!-- PortletHub demo portlets -->
+                <module>ChatRoomDemo</module>
+                <module>PortletHubDemo</module>
+                <module>PortletV3Demo</module>
+                <module>PortletV3AnnotatedDemo</module>
 
-        <!-- Pluto Utilities, Maven Plugins and Ant Tasks -->
-        <module>pluto-util</module>
-        <module>maven-pluto-plugin</module>
-        <module>pluto-ant-tasks</module>
-        <module>pluto-site-skin</module>
+                <!-- Pluto Utilities, Maven Plugins and Ant Tasks -->
+                <module>pluto-util</module>
+                <module>maven-pluto-plugin</module>
+                <module>pluto-ant-tasks</module>
+                <module>pluto-site-skin</module>
         
-        <!-- the Technology Compliance Kit -->
-        <module>portlet-tck_3.0</module>
-      </modules>
-    </profile>
+                <!-- the Technology Compliance Kit -->
+                <module>portlet-tck_3.0</module>
+            </modules>
+        </profile>
     
-    <profile>
-      <id>website</id>
-      <!-- For building website documentation, there's no need to include modules. -->
-      <modules />
-    </profile>
+        <profile>
+            <id>website</id>
+            <!-- For building website documentation, there's no need to include modules. -->
+            <modules />
+        </profile>
     
-    <!-- To build Pluto for deployment on tomee, activate this profile -->
-    <!-- Activate using the tomee property: mvn clean install -Dtomee -->
-    <profile>
-      <id>tomee</id>
-      <activation>
-        <property>
-          <name>tomee</name>
-        </property>
-      </activation>
-      <properties>
-         <!-- scope of certain dependencies is "compile" for deployment on tomcat, 
-              but "provided" for deployment on tomee. See tomee profile. -->
-		  <dependency.scope>provided</dependency.scope>
-      </properties>
-    </profile>
+        <!-- To build Pluto for deployment on tomee, activate this profile -->
+        <!-- Activate using the tomee property: mvn clean install -Dtomee -->
+        <profile>
+            <id>tomee</id>
+            <activation>
+                <property>
+                    <name>tomee</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- scope of certain dependencies is "compile" for deployment on tomcat, 
+                but "provided" for deployment on tomee. See tomee profile. -->
+                <dependency.scope>provided</dependency.scope>
+            </properties>
+      
+            <!-- The artifacts needed for tomee -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
 
-  </profiles>
+                        <configuration>
+                            <excludeScope>test</excludeScope>
+                            <excludeScope>compile</excludeScope>
+
+                            <artifactItems>
+                                <!-- The Spec -->
+                                <artifactItem>
+                                    <groupId>javax.portlet</groupId>
+                                    <artifactId>portlet-api</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                
+                                <!-- Pluto Implementation -->
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container-api</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-container-driver-api</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-taglib</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                                <!-- Pluto portal wars -->
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-portal</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${domainDir}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.portals.pluto</groupId>
+                                    <artifactId>pluto-testsuite</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${domainDir}</outputDirectory>
+                                </artifactItem>
+                                    
+                                <!-- 3rd Party Libraries -->
+                                <artifactItem>
+                                    <groupId>eu.infomas</groupId>
+                                    <artifactId>annotation-detector</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>    
+                                <artifactItem>
+                                    <groupId>javax.ccpp</groupId>
+                                    <artifactId>ccpp</artifactId>
+                                    <type>jar</type>
+                                    <outputDirectory>${libDir}</outputDirectory>
+                                </artifactItem>
+                       
+                            </artifactItems>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 
 </project>


### PR DESCRIPTION
I added two new new ant build files (copy from dist-build.xml) to create a tomee and wildfly distribution.
It differs from the original tomcat one:
- Download tomee or wildfly rather than tomcat
- Add openwebbeans scan property (as we are now using existing openwebbeans rather than weld for CDI) (Tomee only)
- Created module for wildfly dependency (Wildfly only)
- Use mvn dependency:copy rather than mvn pluto:install to copy the artifacts to the correct place. I also manage the dependancies in the tomee / wildfly profile in pom.xml rather than hardcoded in pluto utils java code. This way it's easier to add more distros

If you have any concerns please let me know. Thanks