### PR TITLE
PageAdminPortlet created context paths with double slash for addPortlet

### DIFF
--- a/pluto-portal-driver/src/main/java/org/apache/pluto/driver/portlets/PageAdminPortlet.java
+++ b/pluto-portal-driver/src/main/java/org/apache/pluto/driver/portlets/PageAdminPortlet.java
@@ -80,7 +80,7 @@ public class PageAdminPortlet extends GenericPlutoPortlet {
         LOG.info("Request: Add [applicationName=" + applicationName + ":portletName=" + portletName + "] to page '" + page + "'");
 
         String contextPath = applicationName;
-        if (contextPath.length() > 0)
+        if (contextPath.length() > 0 && !contextPath.startsWith("/"))
         {
             contextPath = "/" + contextPath;
         }


### PR DESCRIPTION
PageAdminPortlet created context paths with a double leading slash in some cases when adding portlets to a page. This is not expected by addPortlet.